### PR TITLE
feat: Categories Page - Liste aller Kategorien

### DIFF
--- a/app/ui/pages/__init__.py
+++ b/app/ui/pages/__init__.py
@@ -4,6 +4,7 @@ Importiert alle Pages um sie bei NiceGUI zu registrieren.
 """
 
 from . import add_item  # noqa: F401
+from . import categories  # noqa: F401
 from . import dashboard  # noqa: F401
 from . import login  # noqa: F401
 from . import more  # noqa: F401

--- a/app/ui/pages/categories.py
+++ b/app/ui/pages/categories.py
@@ -1,0 +1,58 @@
+"""Categories Page - Admin page for managing categories (Mobile-First).
+
+Based on Issue #20: Categories Page - Liste aller Kategorien
+"""
+
+from ...auth import Permission
+from ...auth import require_permissions
+from ...database import get_session
+from ...services import category_service
+from ..components import create_mobile_page_container
+from nicegui import ui
+
+
+@ui.page("/admin/categories")
+@require_permissions(Permission.CONFIG_MANAGE)
+def categories_page() -> None:
+    """Categories management page (Mobile-First)."""
+
+    # Header
+    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+        with ui.row().classes("items-center gap-2"):
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/settings")).props("flat round color=gray-7")
+            ui.label("Kategorien").classes("text-h5 font-bold text-primary")
+
+    # Main content with bottom nav spacing
+    with create_mobile_page_container():
+        ui.label("Kategorien verwalten").classes("text-h6 font-semibold mb-3")
+
+        with next(get_session()) as session:
+            categories = category_service.get_all_categories(session)
+
+            if categories:
+                # Display categories as cards
+                for category in categories:
+                    with ui.card().classes("w-full mb-2"):
+                        with ui.row().classes("w-full items-center justify-between"):
+                            with ui.row().classes("items-center gap-3"):
+                                # Color indicator
+                                if category.color:
+                                    ui.element("div").classes("w-6 h-6 rounded-full").style(
+                                        f"background-color: {category.color}"
+                                    )
+                                else:
+                                    ui.element("div").classes("w-6 h-6 rounded-full bg-gray-300")
+                                # Category name
+                                ui.label(category.name).classes("font-medium text-lg")
+                            # Freeze time info (if set)
+                            if category.freeze_time_months:
+                                ui.label(f"{category.freeze_time_months} Mon.").classes("text-sm text-gray-600")
+            else:
+                # Empty state
+                with ui.card().classes("w-full"):
+                    with ui.column().classes("w-full items-center py-8"):
+                        ui.icon("category", size="48px").classes("text-gray-400 mb-2")
+                        ui.label("Keine Kategorien vorhanden").classes("text-gray-600 text-center")
+                        ui.label("Kategorien helfen beim Organisieren des Vorrats.").classes(
+                            "text-sm text-gray-500 text-center"
+                        )

--- a/tests/test_ui/test_categories.py
+++ b/tests/test_ui/test_categories.py
@@ -1,0 +1,111 @@
+"""UI Tests for Categories Page (Admin)."""
+
+from app.models.category import Category
+from app.models.user import User
+from nicegui.testing import User as TestUser
+from sqlmodel import Session
+
+
+async def test_categories_page_renders_for_admin(user: TestUser) -> None:
+    """Test that categories page renders for admin users."""
+    # Login as admin (created by isolated_test_database fixture)
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to categories page
+    await user.open("/admin/categories")
+
+    # Check page elements
+    await user.should_see("Kategorien")
+
+
+async def test_categories_page_shows_empty_state(user: TestUser) -> None:
+    """Test that categories page shows empty state when no categories exist."""
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to categories page
+    await user.open("/admin/categories")
+
+    # Should show empty state message
+    await user.should_see("Keine Kategorien vorhanden")
+
+
+async def test_categories_page_displays_categories(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that categories page displays categories with name and color."""
+    # Create test categories
+    with Session(isolated_test_database) as session:
+        cat1 = Category(
+            name="Gemüse",
+            color="#00FF00",
+            created_by=1,  # admin user from fixture
+        )
+        cat2 = Category(
+            name="Fleisch",
+            color="#FF0000",
+            created_by=1,
+        )
+        session.add(cat1)
+        session.add(cat2)
+        session.commit()
+
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to categories page
+    await user.open("/admin/categories")
+
+    # Should see categories
+    await user.should_see("Gemüse")
+    await user.should_see("Fleisch")
+
+
+async def test_categories_page_requires_auth(user: TestUser) -> None:
+    """Test that unauthenticated users are redirected to login."""
+    # Try to access categories without login
+    await user.open("/admin/categories")
+
+    # Should be redirected to login
+    await user.should_see("Anmelden")
+
+
+async def test_categories_page_requires_admin_permission(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that regular users are redirected (no CONFIG_MANAGE permission)."""
+    # Create a regular user
+    with Session(isolated_test_database) as session:
+        regular_user = User(
+            username="testuser",
+            email="testuser@example.com",
+            is_active=True,
+            role="user",
+        )
+        regular_user.set_password("password123")
+        session.add(regular_user)
+        session.commit()
+
+    # Login as regular user
+    await user.open("/login")
+    user.find("Benutzername").type("testuser")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Try to navigate to categories page
+    await user.open("/admin/categories")
+
+    # Regular user should be redirected to dashboard (should not see "Kategorien" header)
+    # They should see the dashboard or a permission error
+    await user.should_not_see("Kategorien verwalten")


### PR DESCRIPTION
## Summary
- Implementiert Admin-Seite `/admin/categories` zur Anzeige aller Kategorien
- Mobile-first Card Layout mit Farb-Indikator und Kategorie-Namen
- Permission-geschützt mit `@require_permissions(CONFIG_MANAGE)`
- Empty State wenn keine Kategorien vorhanden

## Akzeptanzkriterien
- [x] @ui.page('/admin/categories') mit @require_permissions(CONFIG_MANAGE)
- [x] Liste aller Kategorien mit Name und Farbe
- [x] Mobile-first Card Layout
- [x] Tests geschrieben und grün

## Test Plan
- [x] Unit Tests für Page-Rendering für Admin-User
- [x] Test für Empty State
- [x] Test für Kategorien-Anzeige
- [x] Test für Authentication-Redirect
- [x] Test für Permission-Check (Regular User wird redirected)

closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)