### PR TITLE
feat: implement complete session cleanup on logout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def session_fixture() -> Generator[Session, None, None]:
 # Database Isolation for UI Tests
 # ============================================================================
 
+
 @pytest.fixture(scope="function", autouse=True)
 def isolated_test_database(monkeypatch):
     """Isolated In-Memory database for every UI test.
@@ -92,6 +93,7 @@ def isolated_test_database(monkeypatch):
 # UI Package Cleanup (Route Re-registration)
 # ============================================================================
 
+
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_ui_packages():
     """Remove UI package modules after each test.
@@ -117,10 +119,7 @@ def cleanup_ui_packages():
     yield  # Run test first
 
     # Cleanup after test
-    modules_to_remove = [
-        key for key in sys.modules.keys()
-        if key.startswith("app.ui")
-    ]
+    modules_to_remove = [key for key in sys.modules.keys() if key.startswith("app.ui")]
 
     for module in modules_to_remove:
         del sys.modules[module]
@@ -129,6 +128,7 @@ def cleanup_ui_packages():
 # ============================================================================
 # User Fixtures
 # ============================================================================
+
 
 @pytest.fixture(name="test_admin")
 def test_admin_fixture(session: Session) -> User:

--- a/tests/test_services/test_auth_service.py
+++ b/tests/test_services/test_auth_service.py
@@ -1,0 +1,93 @@
+"""Tests for Auth Service - Remember Token functionality."""
+
+from app.models.user import User
+from app.services import auth_service
+from collections.abc import Generator
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session
+from sqlmodel import SQLModel
+from sqlmodel import create_engine
+
+
+@pytest.fixture(name="session")
+def session_fixture() -> Generator[Session, None, None]:
+    """Create In-Memory SQLite session for tests."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="test_user")
+def test_user_fixture(session: Session) -> User:
+    """Create a test user."""
+    user = User(
+        username="testuser",
+        email="test@example.com",
+        is_active=True,
+        role="user",
+    )
+    user.set_password("password123")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+class TestRememberToken:
+    """Tests for Remember Token functionality."""
+
+    def test_generate_remember_token(self, session: Session, test_user: User) -> None:
+        """Test that generate_remember_token creates and stores a token."""
+        # Initially no token
+        assert test_user.remember_token is None
+
+        # Generate token
+        token = auth_service.generate_remember_token(session, test_user)
+
+        # Token should be returned and stored
+        assert token is not None
+        assert len(token) > 20  # Should be a secure random string
+        assert test_user.remember_token == token
+
+    def test_revoke_remember_token(self, session: Session, test_user: User) -> None:
+        """Test that revoke_remember_token clears the token."""
+        # First generate a token
+        token = auth_service.generate_remember_token(session, test_user)
+        assert test_user.remember_token == token
+
+        # Revoke the token
+        auth_service.revoke_remember_token(session, test_user)
+
+        # Token should be cleared
+        assert test_user.remember_token is None
+
+    def test_get_user_by_remember_token(self, session: Session, test_user: User) -> None:
+        """Test that get_user_by_remember_token finds user with valid token."""
+        # Generate token
+        token = auth_service.generate_remember_token(session, test_user)
+
+        # Should find user
+        found_user = auth_service.get_user_by_remember_token(session, token)
+        assert found_user is not None
+        assert found_user.id == test_user.id
+
+    def test_get_user_by_remember_token_not_found(self, session: Session) -> None:
+        """Test that get_user_by_remember_token returns None for invalid token."""
+        found_user = auth_service.get_user_by_remember_token(session, "invalid-token")
+        assert found_user is None
+
+    def test_revoked_token_not_found(self, session: Session, test_user: User) -> None:
+        """Test that revoked token can no longer be used to find user."""
+        # Generate and then revoke token
+        token = auth_service.generate_remember_token(session, test_user)
+        auth_service.revoke_remember_token(session, test_user)
+
+        # Token should no longer work
+        found_user = auth_service.get_user_by_remember_token(session, token)
+        assert found_user is None

--- a/tests/test_services/test_freeze_time_service.py
+++ b/tests/test_services/test_freeze_time_service.py
@@ -24,9 +24,7 @@ def test_create_global_freeze_time_config(session: Session, test_admin: User) ->
     assert config.created_by == test_admin.id
 
 
-def test_create_category_specific_freeze_time_config(
-    session: Session, test_admin: User
-) -> None:
+def test_create_category_specific_freeze_time_config(session: Session, test_admin: User) -> None:
     """Test creating a category-specific freeze time config."""
     category = category_service.create_category(
         session=session,
@@ -48,9 +46,7 @@ def test_create_category_specific_freeze_time_config(
     assert config.freeze_time_months == 6
 
 
-def test_create_freeze_time_config_duplicate_fails(
-    session: Session, test_admin: User
-) -> None:
+def test_create_freeze_time_config_duplicate_fails(session: Session, test_admin: User) -> None:
     """Test that duplicate (category_id, item_type) fails."""
     freeze_time_service.create_freeze_time_config(
         session=session,
@@ -71,9 +67,7 @@ def test_create_freeze_time_config_duplicate_fails(
         )
 
 
-def test_create_freeze_time_config_category_duplicate_fails(
-    session: Session, test_admin: User
-) -> None:
+def test_create_freeze_time_config_category_duplicate_fails(session: Session, test_admin: User) -> None:
     """Test that duplicate category-specific config fails."""
     category = category_service.create_category(
         session=session,
@@ -139,9 +133,7 @@ def test_get_freeze_time_config(session: Session, test_admin: User) -> None:
 
 def test_get_freeze_time_config_not_found_fails(session: Session) -> None:
     """Test that getting non-existent freeze time config fails."""
-    with pytest.raises(
-        ValueError, match="Freeze time config with id 999 not found"
-    ):
+    with pytest.raises(ValueError, match="Freeze time config with id 999 not found"):
         freeze_time_service.get_freeze_time_config(session, 999)
 
 
@@ -164,9 +156,7 @@ def test_update_freeze_time_config(session: Session, test_admin: User) -> None:
     assert updated.item_type == ItemType.HOMEMADE_PRESERVED  # Unchanged
 
 
-def test_update_freeze_time_config_to_duplicate_fails(
-    session: Session, test_admin: User
-) -> None:
+def test_update_freeze_time_config_to_duplicate_fails(session: Session, test_admin: User) -> None:
     """Test that updating to duplicate (category_id, item_type) fails."""
     category = category_service.create_category(
         session=session,
@@ -211,9 +201,7 @@ def test_delete_freeze_time_config(session: Session, test_admin: User) -> None:
 
     freeze_time_service.delete_freeze_time_config(session, created.id)
 
-    with pytest.raises(
-        ValueError, match="Freeze time config with id .* not found"
-    ):
+    with pytest.raises(ValueError, match="Freeze time config with id .* not found"):
         freeze_time_service.get_freeze_time_config(session, created.id)
 
 
@@ -252,9 +240,7 @@ def test_get_freeze_time_for_item(session: Session, test_admin: User) -> None:
     assert months == 6
 
 
-def test_get_freeze_time_for_item_falls_back_to_global(
-    session: Session, test_admin: User
-) -> None:
+def test_get_freeze_time_for_item_falls_back_to_global(session: Session, test_admin: User) -> None:
     """Test that freeze time falls back to global if no category-specific config."""
     category = category_service.create_category(
         session=session,
@@ -280,9 +266,7 @@ def test_get_freeze_time_for_item_falls_back_to_global(
     assert months == 3
 
 
-def test_get_freeze_time_for_item_no_config_returns_none(
-    session: Session, test_admin: User
-) -> None:
+def test_get_freeze_time_for_item_no_config_returns_none(session: Session, test_admin: User) -> None:
     """Test that freeze time returns None if no config found."""
     category = category_service.create_category(
         session=session,

--- a/tests/test_services/test_location_service.py
+++ b/tests/test_services/test_location_service.py
@@ -41,9 +41,7 @@ def test_create_location_with_description(session: Session, test_admin: User) ->
     assert location.is_active is True
 
 
-def test_create_location_duplicate_name_fails(
-    session: Session, test_admin: User
-) -> None:
+def test_create_location_duplicate_name_fails(session: Session, test_admin: User) -> None:
     """Test that duplicate location names fail."""
     location_service.create_location(
         session=session,
@@ -52,9 +50,7 @@ def test_create_location_duplicate_name_fails(
         created_by=test_admin.id,
     )
 
-    with pytest.raises(
-        ValueError, match="Location with name 'Vorratsraum' already exists"
-    ):
+    with pytest.raises(ValueError, match="Location with name 'Vorratsraum' already exists"):
         location_service.create_location(
             session=session,
             name="vorratsraum",  # Case-insensitive check
@@ -125,9 +121,7 @@ def test_update_location_name(session: Session, test_admin: User) -> None:
     assert updated.location_type == LocationType.FROZEN  # Unchanged
 
 
-def test_update_location_duplicate_name_fails(
-    session: Session, test_admin: User
-) -> None:
+def test_update_location_duplicate_name_fails(session: Session, test_admin: User) -> None:
     """Test that updating to duplicate name fails."""
     location_service.create_location(
         session=session,
@@ -142,9 +136,7 @@ def test_update_location_duplicate_name_fails(
         created_by=test_admin.id,
     )
 
-    with pytest.raises(
-        ValueError, match="Location with name 'Gefrierschrank' already exists"
-    ):
+    with pytest.raises(ValueError, match="Location with name 'Gefrierschrank' already exists"):
         location_service.update_location(
             session=session,
             id=second.id,

--- a/tests/test_ui/test_logout.py
+++ b/tests/test_ui/test_logout.py
@@ -64,3 +64,41 @@ async def test_mehr_page_shows_username(user: User) -> None:
 
     # Should see username
     await user.should_see("admin")
+
+
+async def test_logout_clears_session(user: User) -> None:
+    """Test that logout clears session and prevents access to protected pages."""
+    # First login
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+    await user.should_see("Willkommen")
+
+    # Navigate to "Mehr" page and logout
+    await user.open("/settings")
+    user.find("Abmelden").click()
+    await user.should_see("Erfolgreich abgemeldet")
+
+    # Try to access protected page - should redirect to login
+    await user.open("/dashboard")
+    await user.should_see("Anmelden")
+
+
+async def test_logout_clears_session_no_remnants(user: User) -> None:
+    """Test that after logout, no session data remains visible."""
+    # First login
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+    await user.should_see("Willkommen")
+
+    # Navigate to "Mehr" page and logout
+    await user.open("/settings")
+    user.find("Abmelden").click()
+    await user.should_see("Erfolgreich abgemeldet")
+
+    # Try to access "Mehr" page again - should redirect to login
+    await user.open("/settings")
+    await user.should_see("Anmelden")

--- a/tests/test_ui/test_save_and_next.py
+++ b/tests/test_ui/test_save_and_next.py
@@ -1,12 +1,8 @@
 """Unit tests for Save & Next flow logic (Phase 7)."""
 
+from app.models.freeze_time_config import ItemType
 from datetime import datetime
 from datetime import timedelta
-from typing import Any
-
-import pytest
-
-from app.models.freeze_time_config import ItemType
 
 
 # Test for Smart Defaults Storage Format

--- a/tests/test_ui/test_wizard_validation.py
+++ b/tests/test_ui/test_wizard_validation.py
@@ -222,9 +222,7 @@ def test_validate_freeze_date_cannot_be_before_best_before() -> None:
     best_before = date(2024, 1, 1)
     freeze_date_val = date(2023, 12, 1)  # Before best_before
 
-    error = validate_freeze_date(
-        freeze_date_val, ItemType.PURCHASED_THEN_FROZEN, best_before
-    )
+    error = validate_freeze_date(freeze_date_val, ItemType.PURCHASED_THEN_FROZEN, best_before)
     assert error is not None
     assert "vor Produktionsdatum" in error
 
@@ -237,9 +235,7 @@ def test_validate_freeze_date_valid_after_best_before() -> None:
     best_before = date(2024, 1, 1)
     freeze_date_val = date(2024, 1, 15)  # After best_before
 
-    error = validate_freeze_date(
-        freeze_date_val, ItemType.PURCHASED_FROZEN, best_before
-    )
+    error = validate_freeze_date(freeze_date_val, ItemType.PURCHASED_FROZEN, best_before)
     assert error is None
 
 


### PR DESCRIPTION
## Summary
- Revoke remember-me token in database when user logs out
- Ensure app.storage.user is completely cleared
- Redirect to login page after logout
- No session remnants remain after logout

## Changes
- **app/ui/auth.py**: Enhanced logout() function to revoke remember token in DB before clearing session
- **tests/test_ui/test_logout.py**: Added tests for session cleanup behavior
- **tests/test_services/test_auth_service.py**: New test file for remember token functionality

## Test plan
- [x] Test: Logout clears session and prevents access to protected pages
- [x] Test: No session remnants after logout
- [x] Test: Remember token generation works
- [x] Test: Remember token revocation works
- [x] Test: Revoked token can no longer be used
- [x] All 140 tests pass
- [x] mypy type check passes
- [x] ruff lint check passes

closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)