### PR TITLE
feat: Locations Page - Liste aller Lagerorte

### DIFF
--- a/app/ui/pages/__init__.py
+++ b/app/ui/pages/__init__.py
@@ -7,6 +7,7 @@ from . import add_item  # noqa: F401
 from . import categories  # noqa: F401
 from . import dashboard  # noqa: F401
 from . import items  # noqa: F401
+from . import locations  # noqa: F401
 from . import login  # noqa: F401
 from . import more  # noqa: F401
 from . import settings  # noqa: F401

--- a/app/ui/pages/locations.py
+++ b/app/ui/pages/locations.py
@@ -1,0 +1,94 @@
+"""Locations Page - Admin page for managing storage locations (Mobile-First).
+
+Based on Issue #24: Locations Page - Liste aller Lagerorte
+"""
+
+from ...auth import Permission
+from ...auth import require_permissions
+from ...database import get_session
+from ...models.location import LocationType
+from ...services import location_service
+from ..components import create_mobile_page_container
+from nicegui import ui
+
+
+def _get_location_type_label(location_type: LocationType) -> str:
+    """Get German label for location type."""
+    labels = {
+        LocationType.FROZEN: "Gefroren",
+        LocationType.CHILLED: "Gekühlt",
+        LocationType.AMBIENT: "Raumtemperatur",
+    }
+    return labels.get(location_type, str(location_type.value))
+
+
+def _get_location_type_color(location_type: LocationType) -> str:
+    """Get color for location type badge."""
+    colors = {
+        LocationType.FROZEN: "blue",
+        LocationType.CHILLED: "cyan",
+        LocationType.AMBIENT: "orange",
+    }
+    return colors.get(location_type, "gray")
+
+
+def _get_location_type_icon(location_type: LocationType) -> str:
+    """Get icon for location type."""
+    icons = {
+        LocationType.FROZEN: "ac_unit",
+        LocationType.CHILLED: "kitchen",
+        LocationType.AMBIENT: "shelves",
+    }
+    return icons.get(location_type, "place")
+
+
+@ui.page("/admin/locations")
+@require_permissions(Permission.CONFIG_MANAGE)
+def locations_page() -> None:
+    """Locations management page (Mobile-First)."""
+
+    # Header
+    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+        with ui.row().classes("items-center gap-2"):
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/settings")).props("flat round color=gray-7")
+            ui.label("Lagerorte").classes("text-h5 font-bold text-primary")
+
+    # Main content with bottom nav spacing
+    with create_mobile_page_container():
+        ui.label("Lagerorte verwalten").classes("text-h6 font-semibold mb-3")
+
+        with next(get_session()) as session:
+            locations = location_service.get_all_locations(session)
+
+            if locations:
+                # Display locations as cards
+                for location in locations:
+                    with ui.card().classes("w-full mb-2"):
+                        with ui.row().classes("w-full items-center justify-between"):
+                            with ui.row().classes("items-center gap-3"):
+                                # Type icon
+                                ui.icon(
+                                    _get_location_type_icon(location.location_type),
+                                    size="24px",
+                                ).classes(f"text-{_get_location_type_color(location.location_type)}")
+                                # Location name
+                                ui.label(location.name).classes("font-medium text-lg")
+                            # Type badge and status
+                            with ui.row().classes("items-center gap-2"):
+                                # Type badge
+                                ui.badge(
+                                    _get_location_type_label(location.location_type),
+                                    color=_get_location_type_color(location.location_type),
+                                ).classes("text-xs")
+                                # Inactive badge (if not active)
+                                if not location.is_active:
+                                    ui.badge("Inaktiv", color="red").classes("text-xs")
+            else:
+                # Empty state
+                with ui.card().classes("w-full"):
+                    with ui.column().classes("w-full items-center py-8"):
+                        ui.icon("place", size="48px").classes("text-gray-400 mb-2")
+                        ui.label("Keine Lagerorte vorhanden").classes("text-gray-600 text-center")
+                        ui.label("Lagerorte helfen beim Organisieren des Vorrats.").classes(
+                            "text-sm text-gray-500 text-center"
+                        )

--- a/tests/test_ui/test_locations.py
+++ b/tests/test_ui/test_locations.py
@@ -1,0 +1,192 @@
+"""UI Tests for Locations Page (Admin)."""
+
+from app.models.location import Location
+from app.models.location import LocationType
+from app.models.user import User
+from nicegui.testing import User as TestUser
+from sqlmodel import Session
+
+
+async def test_locations_page_renders_for_admin(user: TestUser) -> None:
+    """Test that locations page renders for admin users."""
+    # Login as admin (created by isolated_test_database fixture)
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to locations page
+    await user.open("/admin/locations")
+
+    # Check page elements
+    await user.should_see("Lagerorte")
+
+
+async def test_locations_page_shows_empty_state(user: TestUser) -> None:
+    """Test that locations page shows empty state when no locations exist."""
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to locations page
+    await user.open("/admin/locations")
+
+    # Should show empty state message
+    await user.should_see("Keine Lagerorte vorhanden")
+
+
+async def test_locations_page_displays_locations(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that locations page displays locations with name and type."""
+    # Create test locations
+    with Session(isolated_test_database) as session:
+        loc1 = Location(
+            name="Tiefkühltruhe",
+            location_type=LocationType.FROZEN,
+            created_by=1,  # admin user from fixture
+        )
+        loc2 = Location(
+            name="Kühlschrank",
+            location_type=LocationType.CHILLED,
+            created_by=1,
+        )
+        loc3 = Location(
+            name="Speisekammer",
+            location_type=LocationType.AMBIENT,
+            created_by=1,
+        )
+        session.add(loc1)
+        session.add(loc2)
+        session.add(loc3)
+        session.commit()
+
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to locations page
+    await user.open("/admin/locations")
+
+    # Should see locations
+    await user.should_see("Tiefkühltruhe")
+    await user.should_see("Kühlschrank")
+    await user.should_see("Speisekammer")
+
+
+async def test_locations_page_shows_location_types(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that locations page displays location type badges."""
+    # Create test locations with different types
+    with Session(isolated_test_database) as session:
+        loc1 = Location(
+            name="Gefrierschrank",
+            location_type=LocationType.FROZEN,
+            created_by=1,
+        )
+        loc2 = Location(
+            name="Kühlfach",
+            location_type=LocationType.CHILLED,
+            created_by=1,
+        )
+        session.add(loc1)
+        session.add(loc2)
+        session.commit()
+
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to locations page
+    await user.open("/admin/locations")
+
+    # Should see type badges (German labels)
+    await user.should_see("Gefroren")
+    await user.should_see("Gekühlt")
+
+
+async def test_locations_page_requires_auth(user: TestUser) -> None:
+    """Test that unauthenticated users are redirected to login."""
+    # Try to access locations without login
+    await user.open("/admin/locations")
+
+    # Should be redirected to login
+    await user.should_see("Anmelden")
+
+
+async def test_locations_page_requires_admin_permission(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that regular users are redirected (no CONFIG_MANAGE permission)."""
+    # Create a regular user
+    with Session(isolated_test_database) as session:
+        regular_user = User(
+            username="testuser",
+            email="testuser@example.com",
+            is_active=True,
+            role="user",
+        )
+        regular_user.set_password("password123")
+        session.add(regular_user)
+        session.commit()
+
+    # Login as regular user
+    await user.open("/login")
+    user.find("Benutzername").type("testuser")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Try to navigate to locations page
+    await user.open("/admin/locations")
+
+    # Regular user should be redirected (should not see locations page header)
+    await user.should_not_see("Lagerorte verwalten")
+
+
+async def test_locations_page_shows_active_status(
+    user: TestUser,
+    isolated_test_database,
+) -> None:
+    """Test that locations page shows active/inactive status."""
+    # Create test locations with different status
+    with Session(isolated_test_database) as session:
+        loc_active = Location(
+            name="Aktiver Lagerort",
+            location_type=LocationType.AMBIENT,
+            is_active=True,
+            created_by=1,
+        )
+        loc_inactive = Location(
+            name="Inaktiver Lagerort",
+            location_type=LocationType.AMBIENT,
+            is_active=False,
+            created_by=1,
+        )
+        session.add(loc_active)
+        session.add(loc_inactive)
+        session.commit()
+
+    # Login as admin
+    await user.open("/login")
+    user.find("Benutzername").type("admin")
+    user.find("Passwort").type("password123")
+    user.find("Anmelden").click()
+
+    # Navigate to locations page
+    await user.open("/admin/locations")
+
+    # Should see both locations
+    await user.should_see("Aktiver Lagerort")
+    await user.should_see("Inaktiver Lagerort")
+    # Inactive location should show "Inaktiv" badge
+    await user.should_see("Inaktiv")


### PR DESCRIPTION
## Summary
- Add `/admin/locations` page with `@require_permissions(CONFIG_MANAGE)`
- Display locations as mobile-first card layout with name, type badge, and status
- Show type badges (Gefroren/Gekühlt/Raumtemperatur) with corresponding icons
- Show "Inaktiv" badge for inactive locations
- Empty state when no locations exist

closes #24

## Test plan
- [x] All 7 UI tests pass
- [x] Admin can access /admin/locations
- [x] Regular users are redirected (no CONFIG_MANAGE permission)
- [x] Unauthenticated users redirected to login
- [x] Locations display with name, type, and status
- [x] Empty state shown when no locations exist
- [x] All quality checks pass (pytest, mypy, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)