### PR TITLE
chore: split GH Actions to run test and lint/mypy parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,22 @@ jobs:
           SECRET_KEY: test-secret-key-for-ci-only
           FUELLHORN_SECRET: test-fuellhorn-secret-for-ci-only
 
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync
+
       - name: Type check
         run: uv run mypy app/
 


### PR DESCRIPTION
closes #57

## Änderungen

Die CI-Workflow-Datei wurde aufgeteilt, um Tests und Linting/Type-Checking parallel auszuführen:

- **test job**: Führt `pytest` aus
- **lint job**: Führt `mypy`, `ruff check` und `ruff format --check` aus

Da kein `needs:`-Schlüssel zwischen den Jobs definiert ist, laufen beide Jobs in GitHub Actions parallel, was die CI-Geschwindigkeit verbessert.

## Vorher

```
Jobs (sequentiell):
1. test
  - pytest
  - mypy
  - ruff check
  - ruff format --check
```

## Nachher

```
Jobs (parallel):
1. test
  - pytest

2. lint
  - mypy
  - ruff check
  - ruff format --check
```

## Akzeptanzkriterium erfüllt

✅ In der GitHub Actions UI sieht man beide Jobs parallel laufen

🤖 Generated with [Claude Code](https://claude.com/claude-code)