### PR TITLE
fix: TK-Ware gekauft (PURCHASED_FROZEN) benötigt kein Einfrierdatum (#52)

### DIFF
--- a/app/services/expiry_calculator.py
+++ b/app/services/expiry_calculator.py
@@ -20,43 +20,43 @@ def calculate_expiry_date(
 
     Expiry calculation rules by item type:
     - PURCHASED_FRESH: best_before_date + freeze_time_months
-    - HOMEMADE_PRESERVED: best_before_date + freeze_time_months
-    - PURCHASED_FROZEN: freeze_date + freeze_time_months (requires freeze_date)
+    - PURCHASED_FROZEN: best_before_date (MHD on package, no freeze_date needed)
     - PURCHASED_THEN_FROZEN: freeze_date + freeze_time_months (requires freeze_date)
     - HOMEMADE_FROZEN: freeze_date + freeze_time_months (requires freeze_date)
+    - HOMEMADE_PRESERVED: best_before_date + freeze_time_months
 
     If freeze_time_months is None, uses best_before_date as expiry.
 
     Args:
         item_type: Type of item
         best_before_date: Best before/manufacture date
-        freeze_date: Date when item was frozen (required for frozen types)
+        freeze_date: Date when item was frozen (required for self-frozen types)
         freeze_time_months: Storage time in months from config (optional)
 
     Returns:
         Calculated expiry date
 
     Raises:
-        ValueError: If frozen item without freeze_date
+        ValueError: If self-frozen item without freeze_date
     """
     # If no freeze_time config, use best_before_date as-is
     if freeze_time_months is None:
         return best_before_date
 
-    # Frozen items use freeze_date as base
-    frozen_types = {
-        ItemType.PURCHASED_FROZEN,
+    # Only self-frozen items use freeze_date as base
+    # PURCHASED_FROZEN uses best_before_date (MHD on package)
+    self_frozen_types = {
         ItemType.PURCHASED_THEN_FROZEN,
         ItemType.HOMEMADE_FROZEN,
     }
 
-    if item_type in frozen_types:
+    if item_type in self_frozen_types:
         if freeze_date is None:
-            raise ValueError("Frozen items must have a freeze_date")
+            raise ValueError("Self-frozen items must have a freeze_date")
 
         return freeze_date + relativedelta(months=freeze_time_months)
 
-    # All other types use best_before_date as base
+    # All other types (including PURCHASED_FROZEN) use best_before_date as base
     return best_before_date + relativedelta(months=freeze_time_months)
 
 

--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -237,9 +237,9 @@ def add_item() -> None:
                             )
             best_before_input.on("blur", update_step2_validation)
 
-            # Freeze Date (conditional - only for frozen types)
+            # Freeze Date (conditional - only for self-frozen types)
+            # PURCHASED_FROZEN has MHD on package, no freeze_date needed
             frozen_types = {
-                ItemType.PURCHASED_FROZEN,
                 ItemType.PURCHASED_THEN_FROZEN,
                 ItemType.HOMEMADE_FROZEN,
             }

--- a/app/ui/validation/wizard_validation.py
+++ b/app/ui/validation/wizard_validation.py
@@ -149,8 +149,9 @@ def validate_freeze_date(
     # Import here to avoid circular dependency
     from ...models.freeze_time_config import ItemType
 
+    # Only self-frozen items require freeze_date
+    # PURCHASED_FROZEN has MHD on package, no freeze_date needed
     frozen_types = {
-        ItemType.PURCHASED_FROZEN,
         ItemType.PURCHASED_THEN_FROZEN,
         ItemType.HOMEMADE_FROZEN,
     }

--- a/tests/test_services/test_expiry_calculator.py
+++ b/tests/test_services/test_expiry_calculator.py
@@ -39,27 +39,29 @@ def test_calculate_expiry_for_jarred_item() -> None:
 
 
 def test_calculate_expiry_for_frozen_item() -> None:
-    """Test expiry calculation for purchased frozen items."""
-    # Purchased frozen: freeze_date + X months
+    """Test expiry calculation for purchased frozen items (TK-Ware).
+
+    PURCHASED_FROZEN uses best_before_date (MHD on package), not freeze_date.
+    """
     best_before = date(2024, 1, 1)
-    freeze_date_val = date(2024, 6, 1)
     freeze_time_months = 12
 
+    # PURCHASED_FROZEN doesn't need freeze_date (MHD on package)
     expiry = expiry_calculator.calculate_expiry_date(
         item_type=ItemType.PURCHASED_FROZEN,
         best_before_date=best_before,
-        freeze_date=freeze_date_val,
+        freeze_date=None,
         freeze_time_months=freeze_time_months,
     )
 
-    assert expiry == date(2025, 6, 1)  # freeze_date + 12 months
+    assert expiry == date(2025, 1, 1)  # best_before_date + 12 months
 
 
 def test_calculate_expiry_for_frozen_item_without_freeze_date_fails() -> None:
-    """Test that frozen item without freeze_date raises error."""
-    with pytest.raises(ValueError, match="Frozen items must have a freeze_date"):
+    """Test that self-frozen item without freeze_date raises error."""
+    with pytest.raises(ValueError, match="Self-frozen items must have a freeze_date"):
         expiry_calculator.calculate_expiry_date(
-            item_type=ItemType.PURCHASED_FROZEN,
+            item_type=ItemType.PURCHASED_THEN_FROZEN,
             best_before_date=date(2024, 1, 1),
             freeze_date=None,
             freeze_time_months=12,

--- a/tests/test_services/test_item_service.py
+++ b/tests/test_services/test_item_service.py
@@ -28,11 +28,12 @@ def test_create_item(session: Session, test_admin: User) -> None:
         created_by=test_admin.id,
     )
 
+    # PURCHASED_FROZEN (TK-Ware) doesn't need freeze_date (has MHD)
     item = item_service.create_item(
         session=session,
         product_name="Rindfleisch",
         best_before_date=date(2024, 1, 1),
-        freeze_date=date(2024, 6, 1),
+        freeze_date=None,  # Not needed for PURCHASED_FROZEN
         quantity=1.5,
         unit="kg",
         item_type=ItemType.PURCHASED_FROZEN,
@@ -42,7 +43,7 @@ def test_create_item(session: Session, test_admin: User) -> None:
 
     assert item.id is not None
     assert item.product_name == "Rindfleisch"
-    assert item.expiry_date == date(2025, 6, 1)  # freeze_date + 12 months
+    assert item.expiry_date == date(2025, 1, 1)  # best_before_date + 12 months
     assert item.is_consumed is False
 
 

--- a/tests/test_ui/test_wizard_validation.py
+++ b/tests/test_ui/test_wizard_validation.py
@@ -188,13 +188,16 @@ def test_validate_best_before_date_none() -> None:
 
 
 def test_validate_freeze_date_required_for_frozen() -> None:
-    """Test freeze date required for frozen types."""
+    """Test freeze date required for self-frozen types only."""
     from app.ui.validation import validate_freeze_date
     from datetime import date
 
+    # PURCHASED_FROZEN (TK-Ware gekauft) should NOT require freeze_date
+    # It has MHD on the package, no freeze date needed
     error = validate_freeze_date(None, ItemType.PURCHASED_FROZEN, date.today())
-    assert error == "Einfrierdatum erforderlich für TK-Artikel"
+    assert error is None
 
+    # Only self-frozen items require freeze_date
     error = validate_freeze_date(None, ItemType.PURCHASED_THEN_FROZEN, date.today())
     assert error == "Einfrierdatum erforderlich für TK-Artikel"
 
@@ -203,13 +206,19 @@ def test_validate_freeze_date_required_for_frozen() -> None:
 
 
 def test_validate_freeze_date_not_required_for_fresh() -> None:
-    """Test freeze date not required for fresh types."""
+    """Test freeze date not required for non-self-frozen types."""
     from app.ui.validation import validate_freeze_date
     from datetime import date
 
+    # Fresh items don't need freeze date
     error = validate_freeze_date(None, ItemType.PURCHASED_FRESH, date.today())
     assert error is None
 
+    # Purchased frozen (TK-Ware) doesn't need freeze date - has MHD
+    error = validate_freeze_date(None, ItemType.PURCHASED_FROZEN, date.today())
+    assert error is None
+
+    # Preserved items don't need freeze date
     error = validate_freeze_date(None, ItemType.HOMEMADE_PRESERVED, date.today())
     assert error is None
 


### PR DESCRIPTION
## Summary

Fixes #52 - PURCHASED_FROZEN (TK-Ware gekauft) sollte kein Einfrierdatum haben, sondern nur das MHD.

## Problem

Wenn der User "TK-Ware gekauft" im Wizard auswählt, wird auf Seite 2 ein "Einfrierdatum" angezeigt. Das ist falsch - gekaufte TK-Ware hat ein MHD (Mindesthaltbarkeitsdatum) auf der Packung, aber kein bekanntes Einfrierdatum.

## Lösung

**PURCHASED_FROZEN** wurde aus allen `frozen_types` Listen entfernt. Jetzt werden nur noch selbst eingefrorene Items behandelt:
- ✅ **PURCHASED_THEN_FROZEN** - frisch gekauft und selbst eingefroren → benötigt Einfrierdatum
- ✅ **HOMEMADE_FROZEN** - selbst hergestellt und eingefroren → benötigt Einfrierdatum
- ❌ **PURCHASED_FROZEN** - TK-Ware gekauft → benötigt NUR MHD, kein Einfrierdatum

## Änderungen

1. **Validierung** ([wizard_validation.py](app/ui/validation/wizard_validation.py)):
   - PURCHASED_FROZEN aus `frozen_types` entfernt
   - Benötigt jetzt kein `freeze_date` mehr

2. **UI** ([add_item.py](app/ui/pages/add_item.py)):
   - Einfrierdatum-Feld wird nicht mehr angezeigt für PURCHASED_FROZEN

3. **Expiry Calculator** ([expiry_calculator.py](app/services/expiry_calculator.py)):
   - PURCHASED_FROZEN verwendet `best_before_date` statt `freeze_date`
   - Ablaufdatum: `best_before_date + freeze_time_months`

4. **Tests aktualisiert**:
   - `test_wizard_validation.py` - PURCHASED_FROZEN benötigt kein freeze_date
   - `test_expiry_calculator.py` - Korrektes Ablaufdatum-Verhalten
   - `test_item_service.py` - Item-Erstellung ohne freeze_date

## Test plan

- [x] Alle 210 Tests bestehen
- [x] mypy: keine Fehler
- [x] ruff: keine Fehler
- [ ] Manueller Test: "TK-Ware gekauft" auswählen → Seite 2 zeigt nur MHD, kein Einfrierdatum

## Verhalten nach Item-Typ

| Item-Typ | MHD/Datum | Einfrierdatum | Ablauf-Berechnung |
|----------|-----------|---------------|-------------------|
| **PURCHASED_FRESH** | MHD | ❌ | MHD |
| **PURCHASED_FROZEN** | MHD | ❌ | MHD |
| **PURCHASED_THEN_FROZEN** | Kaufdatum | ✅ | Einfrierdatum + Monate |
| **HOMEMADE_FROZEN** | Produktionsdatum | ✅ | Einfrierdatum + Monate |
| **HOMEMADE_PRESERVED** | Produktionsdatum | ❌ | Produktionsdatum + Monate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)