### PR TITLE
feat: Items Page - Filter nach Kategorie

### DIFF
--- a/app/ui/pages/items.py
+++ b/app/ui/pages/items.py
@@ -3,18 +3,23 @@
 Displays all non-consumed items as cards with expiry status.
 Based on requirements from Issue #9.
 Search functionality added in Issue #10.
+Category filter added in Issue #11.
 Extended in Issue #17 to allow showing consumed items via toggle.
 """
 
 from ...auth import require_auth
 from ...database import get_session
 from ...models.item import Item
+from ...models.item import ItemCategory
+from ...services import category_service
 from ...services import item_service
 from ..components import create_bottom_nav
 from ..components import create_item_card
 from ..components import create_mobile_page_container
 from nicegui import app
 from nicegui import ui
+from sqlmodel import Session
+from sqlmodel import select
 from typing import Any
 
 
@@ -34,15 +39,33 @@ def _render_empty_state() -> None:
         ).classes("mt-4")
 
 
-def _render_no_search_results() -> None:
-    """Render message when search yields no results."""
+def _render_no_filter_results() -> None:
+    """Render message when filters yield no results."""
     with ui.card().classes("w-full p-6 text-center"):
         ui.icon("search_off").classes("text-6xl text-gray-300 mb-4")
         ui.label("Keine Artikel gefunden").classes("text-lg text-gray-600 mb-2")
-        ui.label("Versuche einen anderen Suchbegriff").classes("text-sm text-gray-500")
+        ui.label("Versuche andere Filter oder Suchbegriffe").classes("text-sm text-gray-500")
 
 
-def _filter_items(items: list[Item], search_term: str) -> list[Item]:
+def _build_item_category_map(session: Session, items: list[Item]) -> dict[int, set[int]]:
+    """Build a mapping from item IDs to their category IDs.
+
+    Args:
+        session: Database session
+        items: List of items
+
+    Returns:
+        Dictionary mapping item ID to set of category IDs
+    """
+    item_category_map: dict[int, set[int]] = {}
+    for item in items:
+        if item.id is not None:
+            item_cats = session.exec(select(ItemCategory).where(ItemCategory.item_id == item.id)).all()
+            item_category_map[item.id] = {ic.category_id for ic in item_cats}
+    return item_category_map
+
+
+def _filter_items_by_search(items: list[Item], search_term: str) -> list[Item]:
     """Filter items by product name (case-insensitive).
 
     Args:
@@ -59,22 +82,47 @@ def _filter_items(items: list[Item], search_term: str) -> list[Item]:
     return [item for item in items if term_lower in item.product_name.lower()]
 
 
+def _filter_items_by_categories(
+    items: list[Item],
+    selected_categories: set[int],
+    item_category_map: dict[int, set[int]],
+) -> list[Item]:
+    """Filter items by selected categories (OR logic).
+
+    Args:
+        items: List of items to filter
+        selected_categories: Set of selected category IDs
+        item_category_map: Mapping of item IDs to category IDs
+
+    Returns:
+        Filtered list of items that have at least one of the selected categories
+    """
+    if not selected_categories:
+        return items
+
+    return [
+        item for item in items if item.id is not None and item_category_map.get(item.id, set()) & selected_categories
+    ]
+
+
 @ui.page("/items")
 @require_auth
 def items_page() -> None:
-    """Items list page with card layout and search (Mobile-First)."""
+    """Items list page with card layout, search, category filter and consumed toggle (Mobile-First)."""
 
     # Read filter setting from browser storage (default: False = hide consumed)
     show_consumed = app.storage.browser.get(SHOW_CONSUMED_KEY, False)
 
-    # State for search term
+    # State for filters
+    selected_categories: set[int] = set()
+    chip_elements: dict[int, ui.button] = {}
     search_state: dict[str, str] = {"term": ""}
 
-    # Container for items list (for refreshing)
+    # Container reference (for refreshing)
     items_container: Any = None
 
     def refresh_items() -> None:
-        """Refresh items list based on current filter and search settings."""
+        """Refresh items list based on current filter settings."""
         nonlocal items_container
         if items_container is None:
             return
@@ -91,8 +139,13 @@ def items_page() -> None:
                 else:
                     all_items = item_service.get_active_items(session)
 
-                # Apply search filter
-                filtered_items = _filter_items(all_items, search_term)
+                # Build item-to-categories mapping
+                item_category_map = _build_item_category_map(session, all_items)
+
+                # Apply filters
+                filtered_items = list(all_items)
+                filtered_items = _filter_items_by_search(filtered_items, search_term)
+                filtered_items = _filter_items_by_categories(filtered_items, selected_categories, item_category_map)
 
                 if not all_items:
                     # No items at all - show empty state with CTA
@@ -102,8 +155,8 @@ def items_page() -> None:
                     for item in filtered_items:
                         create_item_card(item, session)
                 else:
-                    # Search yielded no results
-                    _render_no_search_results()
+                    # Filters yielded no results
+                    _render_no_filter_results()
 
     def on_toggle_change(e: Any) -> None:
         """Handle toggle change - store setting and refresh list."""
@@ -113,6 +166,30 @@ def items_page() -> None:
     def on_search_change(e: Any) -> None:
         """Handle search input change."""
         search_state["term"] = e.value or ""
+        refresh_items()
+
+    def update_chip_style(cat_id: int) -> None:
+        """Update chip appearance based on selection state."""
+        chip = chip_elements.get(cat_id)
+        if chip:
+            if cat_id in selected_categories:
+                chip.classes(
+                    remove="bg-gray-200 text-gray-800",
+                    add="bg-primary text-white",
+                )
+            else:
+                chip.classes(
+                    remove="bg-primary text-white",
+                    add="bg-gray-200 text-gray-800",
+                )
+
+    def toggle_category(cat_id: int) -> None:
+        """Toggle category selection."""
+        if cat_id in selected_categories:
+            selected_categories.remove(cat_id)
+        else:
+            selected_categories.add(cat_id)
+        update_chip_style(cat_id)
         refresh_items()
 
     # Header with toggle
@@ -130,6 +207,20 @@ def items_page() -> None:
                 placeholder="Produktname...",
                 on_change=on_search_change,
             ).props("clearable").classes("w-full").props("dense outlined")
+
+        # Category filter chips (load categories once)
+        with next(get_session()) as session:
+            all_categories = category_service.get_all_categories(session)
+
+        if all_categories:
+            with ui.row().classes("w-full gap-2 flex-wrap my-2"):
+                for cat in all_categories:
+                    if cat.id is not None:
+                        chip = ui.button(
+                            cat.name,
+                            on_click=lambda _, cid=cat.id: toggle_category(cid),
+                        ).classes("bg-gray-200 text-gray-800 rounded-full px-4 py-1 text-sm")
+                        chip_elements[cat.id] = chip
 
         items_container = ui.column().classes("w-full gap-2")
         refresh_items()

--- a/tests/test_ui/test_items_page.py
+++ b/tests/test_ui/test_items_page.py
@@ -143,3 +143,84 @@ async def test_items_page_toggle_hides_consumed_when_disabled(user: TestUser) ->
     # Should see only active item
     await user.should_see("Aktiver Artikel")
     # Consumed item should not be visible (checked via card count)
+
+
+# Category filter tests (Issue #11)
+
+
+async def test_items_page_shows_category_filter(user: TestUser) -> None:
+    """Test that category filter chips are displayed."""
+    await user.open("/test-items-page-with-categories")
+    # Should see category filter chips
+    await user.should_see("Gemüse")
+    await user.should_see("Fleisch")
+
+
+async def test_items_page_category_filter_shows_all_initially(user: TestUser) -> None:
+    """Test that all items are shown when no category is selected."""
+    await user.open("/test-items-page-with-categories")
+    # Should see all items initially
+    await user.should_see("Tomaten")
+    await user.should_see("Hackfleisch")
+    await user.should_see("Karotten")
+
+
+async def test_items_page_category_filter_filters_items(user: TestUser) -> None:
+    """Test that selecting a category filters items."""
+    await user.open("/test-items-page-with-categories")
+    # Click on Gemüse category chip
+    user.find("Gemüse").click()
+    # Should see items with Gemüse category
+    await user.should_see("Tomaten")
+    await user.should_see("Karotten")
+    # Should not see items without Gemüse category
+    await user.should_not_see("Hackfleisch")
+
+
+async def test_items_page_category_filter_multi_select(user: TestUser) -> None:
+    """Test that multiple categories can be selected."""
+    await user.open("/test-items-page-with-categories")
+    # Click on both categories
+    user.find("Gemüse").click()
+    user.find("Fleisch").click()
+    # Should see items from both categories
+    await user.should_see("Tomaten")
+    await user.should_see("Hackfleisch")
+    await user.should_see("Karotten")
+
+
+async def test_items_page_category_filter_deselect(user: TestUser) -> None:
+    """Test that deselecting a category shows all items again."""
+    await user.open("/test-items-page-with-categories")
+    # Click to select
+    user.find("Gemüse").click()
+    await user.should_not_see("Hackfleisch")
+    # Click again to deselect
+    user.find("Gemüse").click()
+    # Should see all items again
+    await user.should_see("Hackfleisch")
+
+
+async def test_items_page_category_filter_combined_with_search(user: TestUser) -> None:
+    """Test that category filter works together with search."""
+    await user.open("/test-items-page-with-categories")
+    # Select Gemüse category
+    user.find("Gemüse").click()
+    # Should see Tomaten and Karotten
+    await user.should_see("Tomaten")
+    await user.should_see("Karotten")
+    # Search for Tomaten
+    user.find("Suchen").type("Tomat")
+    # Should only see Tomaten (filtered by both category AND search)
+    await user.should_see("Tomaten")
+    await user.should_not_see("Karotten")
+
+
+async def test_items_page_category_filter_no_results(user: TestUser) -> None:
+    """Test that appropriate message is shown when filters yield no results."""
+    await user.open("/test-items-page-with-categories")
+    # Select Gemüse category
+    user.find("Gemüse").click()
+    # Search for something that doesn't exist in Gemüse
+    user.find("Suchen").type("xyz-nicht-vorhanden")
+    await user.should_see("Keine Artikel")


### PR DESCRIPTION
## Summary
- Kategorie-Filter Chips zur Items Page hinzugefügt
- Multi-Select möglich (OR-Logik: zeigt Items mit EINER der ausgewählten Kategorien)
- Mit Suchfunktion kombinierbar
- Visuelle Hervorhebung ausgewählter Kategorien

## Test plan
- [x] UI Tests für Kategorie-Filter (7 neue Tests)
- [x] Tests für Multi-Select
- [x] Tests für Kombination mit Suche
- [x] Tests für Deselect
- [x] mypy und ruff checks bestanden
- [x] Alle 227 Tests grün

closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)