### PR TITLE
feat: Settings Page - Smart Default Zeitfenster konfigurieren

### DIFF
--- a/app/ui/pages/settings.py
+++ b/app/ui/pages/settings.py
@@ -1,6 +1,7 @@
 """Settings Page - Gefrierzeit-Konfiguration (Admin).
 
 Based on Issue #32 and #33: Settings Page to display and manage freeze time configurations.
+Issue #34: Smart Default Zeitfenster konfigurieren.
 """
 
 from ...auth import Permission
@@ -14,9 +15,16 @@ from ...services import category_service
 from ...services import freeze_time_service
 from ..components import create_bottom_nav
 from ..components import create_mobile_page_container
+from nicegui import app
 from nicegui import ui
 from sqlmodel import Session
 from sqlmodel import select
+
+
+# Default time windows in minutes
+DEFAULT_ITEM_TYPE_TIME_WINDOW = 30
+DEFAULT_CATEGORY_TIME_WINDOW = 30
+DEFAULT_LOCATION_TIME_WINDOW = 60
 
 
 # German labels for ItemType
@@ -44,6 +52,12 @@ def settings() -> None:
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
+        # Smart Default Settings section (Issue #34)
+        _render_smart_defaults_section()
+
+        # Separator
+        ui.separator().classes("my-4")
+
         # Section header with "Neu" button
         with ui.row().classes("w-full items-center justify-between mb-3"):
             ui.label("Gefrierzeit-Konfiguration").classes("text-h6 font-semibold")
@@ -53,6 +67,69 @@ def settings() -> None:
 
     # Bottom Navigation
     create_bottom_nav(current_page="settings")
+
+
+def _get_preferences() -> dict:
+    """Get preferences from browser storage with defaults."""
+    preferences = app.storage.browser.get("preferences", {})
+    return {
+        "item_type_time_window": preferences.get("item_type_time_window", DEFAULT_ITEM_TYPE_TIME_WINDOW),
+        "category_time_window": preferences.get("category_time_window", DEFAULT_CATEGORY_TIME_WINDOW),
+        "location_time_window": preferences.get("location_time_window", DEFAULT_LOCATION_TIME_WINDOW),
+    }
+
+
+def _save_preferences(item_type_window: int, category_window: int, location_window: int) -> None:
+    """Save preferences to browser storage."""
+    preferences = app.storage.browser.get("preferences", {})
+    preferences["item_type_time_window"] = item_type_window
+    preferences["category_time_window"] = category_window
+    preferences["location_time_window"] = location_window
+    app.storage.browser["preferences"] = preferences
+    ui.notify("Einstellungen gespeichert", type="positive")
+
+
+def _render_smart_defaults_section() -> None:
+    """Render the Smart Default settings section (Issue #34)."""
+    preferences = _get_preferences()
+
+    ui.label("Smart Default Einstellungen").classes("text-h6 font-semibold mb-3")
+
+    with ui.card().classes("w-full p-4"):
+        ui.label("Zeitfenster für automatische Vorbelegung").classes("text-body2 text-gray-600 mb-3")
+
+        # Item type time window
+        item_type_input = ui.number(
+            label="Artikel-Typ Zeitfenster (Minuten)",
+            value=preferences["item_type_time_window"],
+            min=1,
+            max=120,
+        ).classes("w-full mb-2")
+
+        # Category time window
+        category_input = ui.number(
+            label="Kategorie Zeitfenster (Minuten)",
+            value=preferences["category_time_window"],
+            min=1,
+            max=120,
+        ).classes("w-full mb-2")
+
+        # Location time window
+        location_input = ui.number(
+            label="Lagerort Zeitfenster (Minuten)",
+            value=preferences["location_time_window"],
+            min=1,
+            max=120,
+        ).classes("w-full mb-4")
+
+        # Save button
+        def save_settings() -> None:
+            item_type_val = int(item_type_input.value) if item_type_input.value else DEFAULT_ITEM_TYPE_TIME_WINDOW
+            category_val = int(category_input.value) if category_input.value else DEFAULT_CATEGORY_TIME_WINDOW
+            location_val = int(location_input.value) if location_input.value else DEFAULT_LOCATION_TIME_WINDOW
+            _save_preferences(item_type_val, category_val, location_val)
+
+        ui.button("Speichern", icon="save", on_click=save_settings).props("color=primary")
 
 
 def _render_config_list() -> None:

--- a/tests/test_ui/test_settings.py
+++ b/tests/test_ui/test_settings.py
@@ -177,3 +177,32 @@ async def test_delete_button_opens_confirmation_dialog(
     await logged_in_user.open("/admin/settings")
     logged_in_user.find("delete").click()
     await logged_in_user.should_see("Löschen bestätigen")
+
+
+# =============================================================================
+# Smart Default Zeitfenster Tests (Issue #34)
+# =============================================================================
+
+
+async def test_settings_page_shows_smart_defaults_section(logged_in_user: User) -> None:
+    """Test that settings page has a Smart Defaults section."""
+    await logged_in_user.open("/admin/settings")
+    await logged_in_user.should_see("Smart Default Einstellungen")
+
+
+async def test_settings_page_shows_item_type_time_window(logged_in_user: User) -> None:
+    """Test that settings page shows item type time window input."""
+    await logged_in_user.open("/admin/settings")
+    await logged_in_user.should_see("Artikel-Typ Zeitfenster")
+
+
+async def test_settings_page_shows_category_time_window(logged_in_user: User) -> None:
+    """Test that settings page shows category time window input."""
+    await logged_in_user.open("/admin/settings")
+    await logged_in_user.should_see("Kategorie Zeitfenster")
+
+
+async def test_settings_page_shows_location_time_window(logged_in_user: User) -> None:
+    """Test that settings page shows location time window input."""
+    await logged_in_user.open("/admin/settings")
+    await logged_in_user.should_see("Lagerort Zeitfenster")


### PR DESCRIPTION
## Summary
- Neue Sektion "Smart Default Einstellungen" zur Settings-Page hinzugefügt
- Konfigurierbare Zeitfenster für Artikel-Typ, Kategorie und Lagerort
- Werte werden im Browser Storage gespeichert (persistiert über Sessions)

## Test plan
- [x] UI-Tests für die neue Sektion geschrieben und grün
- [x] Alle 244 Tests grün
- [x] mypy: Keine Fehler
- [x] ruff: Alle Checks bestanden

closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)