### PR TITLE
feat: Users Page - Benutzer bearbeiten

### DIFF
--- a/app/ui/pages/users.py
+++ b/app/ui/pages/users.py
@@ -2,6 +2,7 @@
 
 Based on Issue #28: Users Page - Liste aller Benutzer
 Issue #29: Users Page - Benutzer erstellen
+Issue #30: Users Page - Benutzer bearbeiten
 """
 
 from ...auth import Permission
@@ -51,20 +52,36 @@ def _render_users_list() -> None:
                             role_color = "primary" if user.role == "admin" else "grey"
                             ui.badge(role_display, color=role_color).classes("mt-1")
 
-                        # Right side: status and last login
-                        with ui.column().classes("gap-0 items-end"):
-                            # Status indicator
-                            status_text = "Aktiv" if user.is_active else "Inaktiv"
-                            status_color = "text-green-600" if user.is_active else "text-red-600"
-                            ui.label(status_text).classes(f"text-sm font-medium {status_color}")
+                        # Right side: status, last login, and edit button
+                        with ui.row().classes("items-center gap-2"):
+                            with ui.column().classes("gap-0 items-end"):
+                                # Status indicator
+                                status_text = "Aktiv" if user.is_active else "Inaktiv"
+                                status_color = "text-green-600" if user.is_active else "text-red-600"
+                                ui.label(status_text).classes(f"text-sm font-medium {status_color}")
 
-                            # Last login
-                            if user.last_login:
-                                login_date = user.last_login.strftime("%d.%m.%Y")
-                                login_time = user.last_login.strftime("%H:%M")
-                                ui.label(f"{login_date} {login_time}").classes("text-xs text-gray-500")
-                            else:
-                                ui.label("Nie angemeldet").classes("text-xs text-gray-400")
+                                # Last login
+                                if user.last_login:
+                                    login_date = user.last_login.strftime("%d.%m.%Y")
+                                    login_time = user.last_login.strftime("%H:%M")
+                                    ui.label(f"{login_date} {login_time}").classes("text-xs text-gray-500")
+                                else:
+                                    ui.label("Nie angemeldet").classes("text-xs text-gray-400")
+
+                            # Edit button - capture user data for the closure
+                            user_id = user.id
+                            username = user.username
+                            email = user.email
+                            role = user.role
+                            is_active = user.is_active
+                            ui.button(
+                                icon="edit",
+                                on_click=lambda uid=user_id,
+                                un=username,
+                                em=email,
+                                ro=role,
+                                ia=is_active: _open_edit_dialog(uid, un, em, ro, ia),
+                            ).props("flat round color=grey-7 size=sm").mark(f"edit-{username}")
         else:
             # Empty state (shouldn't happen since there's always at least one admin)
             with ui.card().classes("w-full"):
@@ -186,5 +203,133 @@ def _open_create_dialog() -> None:
                     error_label.set_visibility(True)
 
             ui.button("Speichern", on_click=save_user).props("color=primary")
+
+    dialog.open()
+
+
+def _open_edit_dialog(
+    user_id: int,
+    current_username: str,
+    current_email: str,
+    current_role: str,
+    current_is_active: bool,
+) -> None:
+    """Open dialog to edit an existing user."""
+    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
+        ui.label("Benutzer bearbeiten").classes("text-h6 font-semibold mb-4")
+
+        # Username input (pre-filled)
+        username_input = (
+            ui.input(label="Benutzername", value=current_username)
+            .classes("w-full mb-2")
+            .props("outlined")
+            .mark("edit-username")
+        )
+
+        # Email input (pre-filled)
+        email_input = (
+            ui.input(label="E-Mail", value=current_email).classes("w-full mb-2").props("outlined").mark("edit-email")
+        )
+
+        # Role selection (pre-filled)
+        role_options = {Role.USER.value: "Benutzer", Role.ADMIN.value: "Admin"}
+        role_select = (
+            ui.select(
+                label="Rolle",
+                options=role_options,
+                value=current_role,
+            )
+            .classes("w-full mb-2")
+            .props("outlined")
+            .mark("edit-role")
+        )
+
+        # Active status toggle
+        is_active_switch = ui.switch("Aktiv", value=current_is_active).classes("mb-4").mark("edit-is-active")
+
+        # Password change section (optional)
+        ui.label("Passwort ändern (optional)").classes("text-sm text-gray-600 mb-2")
+
+        password_input = (
+            ui.input(label="Neues Passwort", password=True, password_toggle_button=True)
+            .classes("w-full mb-2")
+            .props("outlined")
+            .mark("edit-password")
+        )
+
+        password_confirm_input = (
+            ui.input(label="Passwort bestätigen", password=True, password_toggle_button=True)
+            .classes("w-full mb-4")
+            .props("outlined")
+            .mark("edit-password-confirm")
+        )
+
+        # Error label (hidden by default)
+        error_label = ui.label("").classes("text-red-600 text-sm mb-2")
+        error_label.set_visibility(False)
+
+        # Buttons
+        with ui.row().classes("w-full justify-end gap-2"):
+            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+
+            def save_changes() -> None:
+                """Validate and save the user changes."""
+                username = username_input.value.strip() if username_input.value else ""
+                email = email_input.value.strip() if email_input.value else ""
+                role_value = role_select.value
+                is_active = is_active_switch.value
+                password = password_input.value if password_input.value else ""
+                password_confirm = password_confirm_input.value if password_confirm_input.value else ""
+
+                # Validation: username is required
+                if not username:
+                    error_label.set_text("Benutzername ist erforderlich")
+                    error_label.set_visibility(True)
+                    return
+
+                # Validation: email is required
+                if not email:
+                    error_label.set_text("E-Mail ist erforderlich")
+                    error_label.set_visibility(True)
+                    return
+
+                # Validation: if password provided, confirmation must match
+                if password and password != password_confirm:
+                    error_label.set_text("Passwörter stimmen nicht überein")
+                    error_label.set_visibility(True)
+                    return
+
+                # Map role value to Role enum
+                role = Role.ADMIN if role_value == Role.ADMIN.value else Role.USER
+
+                try:
+                    with next(get_session()) as session:
+                        auth_service.update_user(
+                            session=session,
+                            user_id=user_id,
+                            username=username if username != current_username else None,
+                            email=email if email != current_email else None,
+                            password=password if password else None,
+                            role=role if role_value != current_role else None,
+                            is_active=is_active if is_active != current_is_active else None,
+                        )
+                    ui.notify(f"Benutzer '{username}' aktualisiert", type="positive")
+                    dialog.close()
+                    ui.navigate.to("/admin/users")
+                except Exception as e:
+                    # Handle duplicate username/email error
+                    error_msg = str(e)
+                    if "UNIQUE constraint" in error_msg:
+                        if "username" in error_msg.lower():
+                            error_label.set_text(f"Benutzername '{username}' bereits vorhanden")
+                        elif "email" in error_msg.lower():
+                            error_label.set_text(f"E-Mail '{email}' bereits vorhanden")
+                        else:
+                            error_label.set_text("Benutzer bereits vorhanden")
+                    else:
+                        error_label.set_text(error_msg)
+                    error_label.set_visibility(True)
+
+            ui.button("Speichern", on_click=save_changes).props("color=primary")
 
     dialog.open()


### PR DESCRIPTION
## Summary
Implementiert Issue #30: Users Page - Benutzer bearbeiten

- **Edit-Button** pro Benutzer in der User-Liste (Marker: `edit-{username}`)
- **Bearbeitungs-Dialog** mit vorausgefüllten Feldern:
  - Benutzername (Marker: `edit-username`)
  - E-Mail (Marker: `edit-email`)
  - Rolle (User/Admin) (Marker: `edit-role`)
  - Aktiv-Status Toggle (Marker: `edit-is-active`)
  - Optionales neues Passwort (Marker: `edit-password`, `edit-password-confirm`)
- **Validierung**:
  - Pflichtfelder (Benutzername, E-Mail)
  - Passwort-Match bei Änderung
  - Eindeutiger Benutzername/E-Mail
- **Permission-geschützt**: Nur Admins mit `USER_MANAGE` Permission

## Tests
- [x] 7 neue UI-Tests für Edit-Funktionalität
- [x] Alle 279 Tests bestehen
- [x] mypy: keine Fehler
- [x] ruff: alle Checks bestanden

closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)