### PR TITLE
chore: docker-compose.yml mit PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,52 @@
+# Fuellhorn - Environment Configuration
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Copy this file to .env and configure your secrets
+# NEVER commit .env to version control!
+
+# =============================================================================
 # Application
+# =============================================================================
 DEBUG=true
 HOST=0.0.0.0
 PORT=8080
 
-# Security
+# =============================================================================
+# Security - REQUIRED!
+# =============================================================================
 # WICHTIG: Generiere sichere Secrets für Production!
 # Python: python -c "import secrets; print(secrets.token_urlsafe(32))"
 SECRET_KEY=your-super-secret-key-here-min-32-chars-CHANGE-ME
 FUELLHORN_SECRET=nicegui-storage-secret-CHANGE-ME
 
-# Database
+# =============================================================================
+# Database - Local Development (SQLite)
+# =============================================================================
 DB_TYPE=sqlite
 DATABASE_URL=sqlite:///data/fuellhorn.db
 
-# For production with PostgreSQL:
+# =============================================================================
+# Database - Docker Compose (PostgreSQL)
+# =============================================================================
+# Uncomment these for docker-compose usage:
 # DB_TYPE=postgresql
-# DATABASE_URL=postgresql://user:password@localhost:5432/fuellhorn
+# DATABASE_URL=postgresql://fuellhorn:your-db-password@db:5432/fuellhorn
 
+# PostgreSQL settings (used by docker-compose.yml)
+POSTGRES_USER=fuellhorn
+POSTGRES_PASSWORD=CHANGE_ME_generate_db_password
+POSTGRES_DB=fuellhorn
+
+# External port for docker-compose (default: 8080)
+APP_PORT=8080
+
+# =============================================================================
 # Session
+# =============================================================================
 SESSION_MAX_AGE=86400
 REMEMBER_ME_MAX_AGE=2592000
 
+# =============================================================================
 # Logging
+# =============================================================================
 LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,15 @@ COPY main.py ./
 COPY alembic.ini ./
 COPY alembic/ ./alembic/
 
-# Create data directory for SQLite database
+# Copy entrypoint script
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+# Create data directory for SQLite database (standalone mode)
 RUN mkdir -p /app/data
 
-# Environment variables
+# Environment variables (defaults for standalone SQLite mode)
+# Override via docker-compose.yml or -e flags for PostgreSQL
 ENV PYTHONUNBUFFERED=1
 ENV DB_TYPE=sqlite
 ENV DATABASE_URL=sqlite:///data/fuellhorn.db
@@ -38,5 +43,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')" || exit 1
 
-# Run the application via the venv Python
-CMD ["/app/.venv/bin/python", "main.py"]
+# Default entrypoint runs migrations then starts app
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+# Fuellhorn - Lebensmittelvorrats-Verwaltung
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Docker Compose Setup for Production with PostgreSQL
+#
+# Usage:
+#   1. Copy .env.example to .env and configure secrets
+#   2. docker compose up -d
+#   3. Access at http://localhost:8080
+#
+# Note: First run will execute Alembic migrations automatically
+
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: fuellhorn-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-fuellhorn}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-fuellhorn}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-fuellhorn} -d ${POSTGRES_DB:-fuellhorn}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - fuellhorn-network
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fuellhorn-app
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # Database Configuration
+      DB_TYPE: postgresql
+      DATABASE_URL: postgresql://${POSTGRES_USER:-fuellhorn}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-fuellhorn}
+      # Security (REQUIRED - set in .env file)
+      SECRET_KEY: ${SECRET_KEY}
+      FUELLHORN_SECRET: ${FUELLHORN_SECRET}
+      # App Configuration
+      DEBUG: ${DEBUG:-false}
+      HOST: 0.0.0.0
+      PORT: 8080
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    networks:
+      - fuellhorn-network
+
+volumes:
+  postgres_data:
+    name: fuellhorn-postgres-data
+
+networks:
+  fuellhorn-network:
+    name: fuellhorn-network

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Fuellhorn - Lebensmittelvorrats-Verwaltung
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Docker entrypoint script
+# Runs Alembic migrations and starts the application
+
+set -e
+
+echo "Running Alembic migrations..."
+/app/.venv/bin/python -m alembic upgrade head
+
+echo "Starting Fuellhorn application..."
+exec /app/.venv/bin/python main.py


### PR DESCRIPTION
## Summary
- Docker Compose Setup für Production mit PostgreSQL 17
- Automatische Alembic Migrations beim Container-Start
- Environment Variables über .env Datei konfigurierbar

## Änderungen
- `docker-compose.yml` - PostgreSQL und App Container mit Health Checks
- `docker-entrypoint.sh` - Führt Migrations aus und startet die App
- `.env.example` - Erweitert um Docker-spezifische Variablen (POSTGRES_USER, POSTGRES_PASSWORD, etc.)
- `Dockerfile` - Entrypoint Script hinzugefügt

## Nutzung
```bash
# 1. Environment konfigurieren
cp .env.example .env
# Secrets generieren und in .env eintragen

# 2. Container starten
docker compose up -d

# 3. Zugriff auf http://localhost:8080
```

## Test
- [x] docker compose config validiert
- [x] Docker Image baut erfolgreich
- [x] Container starten und werden healthy
- [x] Health Endpoint antwortet
- [x] Alembic Migrations werden ausgeführt

closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)