### PR TITLE
feat: Settings Page aufteilen - Navigation zu Admin-Bereichen

### DIFF
--- a/app/ui/pages/__init__.py
+++ b/app/ui/pages/__init__.py
@@ -6,6 +6,7 @@ Importiert alle Pages um sie bei NiceGUI zu registrieren.
 from . import add_item  # noqa: F401
 from . import categories  # noqa: F401
 from . import dashboard  # noqa: F401
+from . import freeze_times  # noqa: F401
 from . import items  # noqa: F401
 from . import locations  # noqa: F401
 from . import login  # noqa: F401

--- a/app/ui/pages/freeze_times.py
+++ b/app/ui/pages/freeze_times.py
@@ -1,0 +1,270 @@
+"""Freeze Times Page - Gefrierzeit-Konfiguration (Admin).
+
+Based on Issue #79: Settings Page aufteilen.
+Extracted from settings.py - freeze time configuration management.
+"""
+
+from ...auth import Permission
+from ...auth import require_permissions
+from ...auth.dependencies import get_current_user
+from ...database import get_session
+from ...models.category import Category
+from ...models.freeze_time_config import FreezeTimeConfig
+from ...models.freeze_time_config import ItemType
+from ...services import category_service
+from ...services import freeze_time_service
+from ..components import create_mobile_page_container
+from nicegui import ui
+from sqlmodel import Session
+from sqlmodel import select
+
+
+# German labels for ItemType
+ITEM_TYPE_LABELS: dict[ItemType, str] = {
+    ItemType.PURCHASED_FRESH: "Frisch gekauft",
+    ItemType.PURCHASED_FROZEN: "TK-Ware gekauft",
+    ItemType.PURCHASED_THEN_FROZEN: "Frisch gekauft, eingefroren",
+    ItemType.HOMEMADE_FROZEN: "Selbst eingefroren",
+    ItemType.HOMEMADE_PRESERVED: "Selbst eingemacht",
+}
+
+# Reverse mapping for select options
+ITEM_TYPE_OPTIONS: dict[str, ItemType] = {v: k for k, v in ITEM_TYPE_LABELS.items()}
+
+
+@ui.page("/admin/freeze-times")
+@require_permissions(Permission.CONFIG_MANAGE)
+def freeze_times_page() -> None:
+    """Freeze time configuration page (Admin only)."""
+    # Header
+    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+        with ui.row().classes("items-center gap-2"):
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).props(
+                "flat round color=gray-7"
+            )
+            ui.label("Gefrierzeiten").classes("text-h5 font-bold text-primary")
+
+    # Main content with bottom nav spacing
+    with create_mobile_page_container():
+        # Section header with "Neu" button
+        with ui.row().classes("w-full items-center justify-between mb-3"):
+            ui.label("Gefrierzeit-Konfiguration").classes("text-h6 font-semibold")
+            ui.button("Neu", icon="add", on_click=lambda: _open_create_dialog()).props("color=primary size=sm")
+
+        _render_config_list()
+
+
+def _render_config_list() -> None:
+    """Render the list of freeze time configurations."""
+    with next(get_session()) as session:
+        configs = freeze_time_service.get_all_freeze_time_configs(session)
+
+        if not configs:
+            # Empty state
+            with ui.card().classes("w-full p-4 bg-gray-50"):
+                ui.label("Keine Gefrierzeit-Konfigurationen vorhanden").classes("text-gray-600")
+        else:
+            # Group configs by ItemType
+            configs_by_type: dict[ItemType, list[FreezeTimeConfig]] = {}
+            for config in configs:
+                if config.item_type not in configs_by_type:
+                    configs_by_type[config.item_type] = []
+                configs_by_type[config.item_type].append(config)
+
+            # Display grouped configs
+            for item_type in ItemType:
+                if item_type not in configs_by_type:
+                    continue
+
+                type_configs = configs_by_type[item_type]
+                type_label = ITEM_TYPE_LABELS.get(item_type, item_type.value)
+
+                # ItemType header
+                ui.label(type_label).classes("text-subtitle1 font-medium mt-4 mb-2")
+
+                # Config cards for this type
+                for config in type_configs:
+                    _render_config_card(session, config)
+
+
+def _render_config_card(session: Session, config: FreezeTimeConfig) -> None:
+    """Render a single freeze time config as a card with edit/delete buttons."""
+    # Get category name if category-specific
+    category_name = None
+    if config.category_id:
+        category = session.exec(select(Category).where(Category.id == config.category_id)).first()
+        if category:
+            category_name = category.name
+
+    # Store config_id for closure
+    config_id = config.id
+
+    with ui.card().classes("w-full mb-2"):
+        with ui.row().classes("w-full items-center justify-between"):
+            with ui.column().classes("flex-1"):
+                if category_name:
+                    ui.label(category_name).classes("font-medium")
+                    ui.label(f"{config.freeze_time_months} Monate").classes("text-sm text-gray-600")
+                else:
+                    ui.label("Standard (Global)").classes("font-medium text-gray-500")
+                    ui.label(f"{config.freeze_time_months} Monate").classes("text-sm text-gray-600")
+
+            # Edit and delete buttons
+            with ui.row().classes("gap-1"):
+                ui.button(
+                    icon="edit",
+                    on_click=lambda cid=config_id: _open_edit_dialog(cid),
+                ).props("flat round color=primary size=sm")
+                ui.button(
+                    icon="delete",
+                    on_click=lambda cid=config_id: _open_delete_dialog(cid),
+                ).props("flat round color=negative size=sm")
+
+
+def _open_create_dialog() -> None:
+    """Open dialog to create a new freeze time configuration."""
+    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
+        ui.label("Neue Gefrierzeit-Konfiguration").classes("text-h6 font-semibold mb-4")
+
+        # Item type select
+        item_type_options = list(ITEM_TYPE_OPTIONS.keys())
+        item_type_select = ui.select(
+            label="Artikel-Typ",
+            options=item_type_options,
+            value=item_type_options[0],
+        ).classes("w-full mb-2")
+
+        # Category select (optional)
+        with next(get_session()) as session:
+            categories = category_service.get_all_categories(session)
+            category_options = {c.name: c.id for c in categories}
+            category_options_list = ["(Global)"] + list(category_options.keys())
+
+        category_select = ui.select(
+            label="Kategorie",
+            options=category_options_list,
+            value="(Global)",
+        ).classes("w-full mb-2")
+
+        # Months input (1-24)
+        months_input = ui.number(
+            label="Monate (1-24)",
+            value=6,
+            min=1,
+            max=24,
+        ).classes("w-full mb-4")
+
+        # Buttons
+        with ui.row().classes("w-full justify-end gap-2"):
+            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+
+            def save_config() -> None:
+                item_type = ITEM_TYPE_OPTIONS[item_type_select.value]
+                category_id = (
+                    category_options.get(category_select.value) if category_select.value != "(Global)" else None
+                )
+                months = int(months_input.value) if months_input.value else 6
+
+                # Validate months range
+                if months < 1 or months > 24:
+                    ui.notify("Monate muss zwischen 1 und 24 liegen", type="negative")
+                    return
+
+                try:
+                    current_user = get_current_user()
+                    if current_user is None or current_user.id is None:
+                        ui.notify("Nicht angemeldet", type="negative")
+                        return
+                    with next(get_session()) as session:
+                        freeze_time_service.create_freeze_time_config(
+                            session=session,
+                            item_type=item_type,
+                            freeze_time_months=months,
+                            created_by=current_user.id,
+                            category_id=category_id,
+                        )
+                    ui.notify("Konfiguration erstellt", type="positive")
+                    dialog.close()
+                    ui.navigate.to("/admin/freeze-times")
+                except ValueError as e:
+                    ui.notify(str(e), type="negative")
+
+            ui.button("Speichern", on_click=save_config).props("color=primary")
+
+    dialog.open()
+
+
+def _open_edit_dialog(config_id: int) -> None:
+    """Open dialog to edit an existing freeze time configuration."""
+    with next(get_session()) as session:
+        config = freeze_time_service.get_freeze_time_config(session, config_id)
+        current_item_type_label = ITEM_TYPE_LABELS[config.item_type]
+        current_months = config.freeze_time_months
+
+    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
+        ui.label("Gefrierzeit bearbeiten").classes("text-h6 font-semibold mb-4")
+
+        # Item type (read-only display)
+        ui.label(f"Artikel-Typ: {current_item_type_label}").classes("text-gray-600 mb-2")
+
+        # Months input (1-24)
+        months_input = ui.number(
+            label="Monate (1-24)",
+            value=current_months,
+            min=1,
+            max=24,
+        ).classes("w-full mb-4")
+
+        # Buttons
+        with ui.row().classes("w-full justify-end gap-2"):
+            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+
+            def update_config() -> None:
+                months = int(months_input.value) if months_input.value else 6
+
+                # Validate months range
+                if months < 1 or months > 24:
+                    ui.notify("Monate muss zwischen 1 und 24 liegen", type="negative")
+                    return
+
+                try:
+                    with next(get_session()) as session:
+                        freeze_time_service.update_freeze_time_config(
+                            session=session,
+                            id=config_id,
+                            freeze_time_months=months,
+                        )
+                    ui.notify("Konfiguration aktualisiert", type="positive")
+                    dialog.close()
+                    ui.navigate.to("/admin/freeze-times")
+                except ValueError as e:
+                    ui.notify(str(e), type="negative")
+
+            ui.button("Speichern", on_click=update_config).props("color=primary")
+
+    dialog.open()
+
+
+def _open_delete_dialog(config_id: int) -> None:
+    """Open confirmation dialog to delete a freeze time configuration."""
+    with ui.dialog() as dialog, ui.card().classes("w-full max-w-sm"):
+        ui.label("Löschen bestätigen").classes("text-h6 font-semibold mb-4")
+        ui.label("Möchten Sie diese Konfiguration wirklich löschen?").classes("mb-4")
+
+        # Buttons
+        with ui.row().classes("w-full justify-end gap-2"):
+            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+
+            def delete_config() -> None:
+                try:
+                    with next(get_session()) as session:
+                        freeze_time_service.delete_freeze_time_config(session=session, id=config_id)
+                    ui.notify("Konfiguration gelöscht", type="positive")
+                    dialog.close()
+                    ui.navigate.to("/admin/freeze-times")
+                except ValueError as e:
+                    ui.notify(str(e), type="negative")
+
+            ui.button("Löschen", on_click=delete_config).props("color=negative")
+
+    dialog.open()

--- a/app/ui/pages/settings.py
+++ b/app/ui/pages/settings.py
@@ -1,24 +1,15 @@
-"""Settings Page - Gefrierzeit-Konfiguration (Admin).
+"""Settings Page - Übersicht und Navigation zu Admin-Bereichen.
 
-Based on Issue #32 and #33: Settings Page to display and manage freeze time configurations.
+Based on Issue #79: Settings Page aufteilen - Navigation zu Admin-Bereichen.
 Issue #34: Smart Default Zeitfenster konfigurieren.
 """
 
 from ...auth import Permission
 from ...auth import require_permissions
-from ...auth.dependencies import get_current_user
-from ...database import get_session
-from ...models.category import Category
-from ...models.freeze_time_config import FreezeTimeConfig
-from ...models.freeze_time_config import ItemType
-from ...services import category_service
-from ...services import freeze_time_service
 from ..components import create_bottom_nav
 from ..components import create_mobile_page_container
 from nicegui import app
 from nicegui import ui
-from sqlmodel import Session
-from sqlmodel import select
 
 
 # Default time windows in minutes
@@ -27,23 +18,10 @@ DEFAULT_CATEGORY_TIME_WINDOW = 30
 DEFAULT_LOCATION_TIME_WINDOW = 60
 
 
-# German labels for ItemType
-ITEM_TYPE_LABELS: dict[ItemType, str] = {
-    ItemType.PURCHASED_FRESH: "Frisch gekauft",
-    ItemType.PURCHASED_FROZEN: "TK-Ware gekauft",
-    ItemType.PURCHASED_THEN_FROZEN: "Frisch gekauft, eingefroren",
-    ItemType.HOMEMADE_FROZEN: "Selbst eingefroren",
-    ItemType.HOMEMADE_PRESERVED: "Selbst eingemacht",
-}
-
-# Reverse mapping for select options
-ITEM_TYPE_OPTIONS: dict[str, ItemType] = {v: k for k, v in ITEM_TYPE_LABELS.items()}
-
-
 @ui.page("/admin/settings")
 @require_permissions(Permission.CONFIG_MANAGE)
 def settings() -> None:
-    """Settings page for freeze time configuration (Admin only)."""
+    """Settings page with admin navigation and smart defaults (Admin only)."""
     # Header
     with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
         with ui.row().classes("items-center gap-2"):
@@ -52,21 +30,42 @@ def settings() -> None:
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
-        # Smart Default Settings section (Issue #34)
-        _render_smart_defaults_section()
+        # Admin Navigation section
+        _render_admin_navigation()
 
         # Separator
         ui.separator().classes("my-4")
 
-        # Section header with "Neu" button
-        with ui.row().classes("w-full items-center justify-between mb-3"):
-            ui.label("Gefrierzeit-Konfiguration").classes("text-h6 font-semibold")
-            ui.button("Neu", icon="add", on_click=lambda: _open_create_dialog()).props("color=primary size=sm")
-
-        _render_config_list()
+        # Smart Default Settings section (Issue #34)
+        _render_smart_defaults_section()
 
     # Bottom Navigation
     create_bottom_nav(current_page="settings")
+
+
+def _render_admin_navigation() -> None:
+    """Render navigation links to admin areas."""
+    ui.label("Verwaltung").classes("text-h6 font-semibold mb-3")
+
+    # Navigation cards
+    nav_items = [
+        {"icon": "category", "label": "Kategorien", "route": "/admin/categories"},
+        {"icon": "place", "label": "Lagerorte", "route": "/admin/locations"},
+        {"icon": "people", "label": "Benutzer", "route": "/admin/users"},
+        {"icon": "ac_unit", "label": "Gefrierzeiten", "route": "/admin/freeze-times"},
+    ]
+
+    for item in nav_items:
+        with (
+            ui.card()
+            .classes("w-full mb-2 cursor-pointer hover:bg-gray-50")
+            .on("click", lambda r=item["route"]: ui.navigate.to(r))
+        ):
+            with ui.row().classes("w-full items-center justify-between p-2"):
+                with ui.row().classes("items-center gap-3"):
+                    ui.icon(item["icon"]).classes("text-primary")
+                    ui.label(item["label"]).classes("font-medium")
+                ui.icon("chevron_right").classes("text-gray-400")
 
 
 def _get_preferences() -> dict:
@@ -130,219 +129,3 @@ def _render_smart_defaults_section() -> None:
             _save_preferences(item_type_val, category_val, location_val)
 
         ui.button("Speichern", icon="save", on_click=save_settings).props("color=primary")
-
-
-def _render_config_list() -> None:
-    """Render the list of freeze time configurations."""
-    with next(get_session()) as session:
-        configs = freeze_time_service.get_all_freeze_time_configs(session)
-
-        if not configs:
-            # Empty state
-            with ui.card().classes("w-full p-4 bg-gray-50"):
-                ui.label("Keine Gefrierzeit-Konfigurationen vorhanden").classes("text-gray-600")
-        else:
-            # Group configs by ItemType
-            configs_by_type: dict[ItemType, list[FreezeTimeConfig]] = {}
-            for config in configs:
-                if config.item_type not in configs_by_type:
-                    configs_by_type[config.item_type] = []
-                configs_by_type[config.item_type].append(config)
-
-            # Display grouped configs
-            for item_type in ItemType:
-                if item_type not in configs_by_type:
-                    continue
-
-                type_configs = configs_by_type[item_type]
-                type_label = ITEM_TYPE_LABELS.get(item_type, item_type.value)
-
-                # ItemType header
-                ui.label(type_label).classes("text-subtitle1 font-medium mt-4 mb-2")
-
-                # Config cards for this type
-                for config in type_configs:
-                    _render_config_card(session, config)
-
-
-def _render_config_card(session: Session, config: FreezeTimeConfig) -> None:
-    """Render a single freeze time config as a card with edit/delete buttons."""
-    # Get category name if category-specific
-    category_name = None
-    if config.category_id:
-        category = session.exec(select(Category).where(Category.id == config.category_id)).first()
-        if category:
-            category_name = category.name
-
-    # Store config_id for closure
-    config_id = config.id
-
-    with ui.card().classes("w-full mb-2"):
-        with ui.row().classes("w-full items-center justify-between"):
-            with ui.column().classes("flex-1"):
-                if category_name:
-                    ui.label(category_name).classes("font-medium")
-                    ui.label(f"{config.freeze_time_months} Monate").classes("text-sm text-gray-600")
-                else:
-                    ui.label("Standard (Global)").classes("font-medium text-gray-500")
-                    ui.label(f"{config.freeze_time_months} Monate").classes("text-sm text-gray-600")
-
-            # Edit and delete buttons
-            with ui.row().classes("gap-1"):
-                ui.button(
-                    icon="edit",
-                    on_click=lambda cid=config_id: _open_edit_dialog(cid),
-                ).props("flat round color=primary size=sm")
-                ui.button(
-                    icon="delete",
-                    on_click=lambda cid=config_id: _open_delete_dialog(cid),
-                ).props("flat round color=negative size=sm")
-
-
-def _open_create_dialog() -> None:
-    """Open dialog to create a new freeze time configuration."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Neue Gefrierzeit-Konfiguration").classes("text-h6 font-semibold mb-4")
-
-        # Item type select
-        item_type_options = list(ITEM_TYPE_OPTIONS.keys())
-        item_type_select = ui.select(
-            label="Artikel-Typ",
-            options=item_type_options,
-            value=item_type_options[0],
-        ).classes("w-full mb-2")
-
-        # Category select (optional)
-        with next(get_session()) as session:
-            categories = category_service.get_all_categories(session)
-            category_options = {c.name: c.id for c in categories}
-            category_options_list = ["(Global)"] + list(category_options.keys())
-
-        category_select = ui.select(
-            label="Kategorie",
-            options=category_options_list,
-            value="(Global)",
-        ).classes("w-full mb-2")
-
-        # Months input (1-24)
-        months_input = ui.number(
-            label="Monate (1-24)",
-            value=6,
-            min=1,
-            max=24,
-        ).classes("w-full mb-4")
-
-        # Buttons
-        with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
-
-            def save_config() -> None:
-                item_type = ITEM_TYPE_OPTIONS[item_type_select.value]
-                category_id = (
-                    category_options.get(category_select.value) if category_select.value != "(Global)" else None
-                )
-                months = int(months_input.value) if months_input.value else 6
-
-                # Validate months range
-                if months < 1 or months > 24:
-                    ui.notify("Monate muss zwischen 1 und 24 liegen", type="negative")
-                    return
-
-                try:
-                    current_user = get_current_user()
-                    if current_user is None or current_user.id is None:
-                        ui.notify("Nicht angemeldet", type="negative")
-                        return
-                    with next(get_session()) as session:
-                        freeze_time_service.create_freeze_time_config(
-                            session=session,
-                            item_type=item_type,
-                            freeze_time_months=months,
-                            created_by=current_user.id,
-                            category_id=category_id,
-                        )
-                    ui.notify("Konfiguration erstellt", type="positive")
-                    dialog.close()
-                    ui.navigate.to("/admin/settings")
-                except ValueError as e:
-                    ui.notify(str(e), type="negative")
-
-            ui.button("Speichern", on_click=save_config).props("color=primary")
-
-    dialog.open()
-
-
-def _open_edit_dialog(config_id: int) -> None:
-    """Open dialog to edit an existing freeze time configuration."""
-    with next(get_session()) as session:
-        config = freeze_time_service.get_freeze_time_config(session, config_id)
-        current_item_type_label = ITEM_TYPE_LABELS[config.item_type]
-        current_months = config.freeze_time_months
-
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Gefrierzeit bearbeiten").classes("text-h6 font-semibold mb-4")
-
-        # Item type (read-only display)
-        ui.label(f"Artikel-Typ: {current_item_type_label}").classes("text-gray-600 mb-2")
-
-        # Months input (1-24)
-        months_input = ui.number(
-            label="Monate (1-24)",
-            value=current_months,
-            min=1,
-            max=24,
-        ).classes("w-full mb-4")
-
-        # Buttons
-        with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
-
-            def update_config() -> None:
-                months = int(months_input.value) if months_input.value else 6
-
-                # Validate months range
-                if months < 1 or months > 24:
-                    ui.notify("Monate muss zwischen 1 und 24 liegen", type="negative")
-                    return
-
-                try:
-                    with next(get_session()) as session:
-                        freeze_time_service.update_freeze_time_config(
-                            session=session,
-                            id=config_id,
-                            freeze_time_months=months,
-                        )
-                    ui.notify("Konfiguration aktualisiert", type="positive")
-                    dialog.close()
-                    ui.navigate.to("/admin/settings")
-                except ValueError as e:
-                    ui.notify(str(e), type="negative")
-
-            ui.button("Speichern", on_click=update_config).props("color=primary")
-
-    dialog.open()
-
-
-def _open_delete_dialog(config_id: int) -> None:
-    """Open confirmation dialog to delete a freeze time configuration."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-sm"):
-        ui.label("Löschen bestätigen").classes("text-h6 font-semibold mb-4")
-        ui.label("Möchten Sie diese Konfiguration wirklich löschen?").classes("mb-4")
-
-        # Buttons
-        with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
-
-            def delete_config() -> None:
-                try:
-                    with next(get_session()) as session:
-                        freeze_time_service.delete_freeze_time_config(session=session, id=config_id)
-                    ui.notify("Konfiguration gelöscht", type="positive")
-                    dialog.close()
-                    ui.navigate.to("/admin/settings")
-                except ValueError as e:
-                    ui.notify(str(e), type="negative")
-
-            ui.button("Löschen", on_click=delete_config).props("color=negative")
-
-    dialog.open()

--- a/tests/test_ui/test_freeze_times.py
+++ b/tests/test_ui/test_freeze_times.py
@@ -1,0 +1,170 @@
+"""UI Tests for Freeze Times Page - Gefrierzeit-Konfiguration.
+
+Issue #79: Settings Page aufteilen - Freeze Times extracted to separate page.
+Based on Issue #32 and #33: Freeze time configuration management.
+"""
+
+from app.models.category import Category
+from app.models.freeze_time_config import FreezeTimeConfig
+from app.models.freeze_time_config import ItemType
+from nicegui.testing import User
+from sqlmodel import Session
+
+
+async def test_freeze_times_page_renders_for_admin(logged_in_user: User) -> None:
+    """Test that freeze times page renders correctly for admin users."""
+    await logged_in_user.open("/admin/freeze-times")
+
+    # Check page elements
+    await logged_in_user.should_see("Gefrierzeiten")
+    await logged_in_user.should_see("Gefrierzeit-Konfiguration")
+
+
+async def test_freeze_times_page_requires_auth(user: User) -> None:
+    """Test that unauthenticated users are redirected to login."""
+    await user.open("/admin/freeze-times")
+    await user.should_see("Anmelden")
+
+
+async def test_freeze_times_page_shows_configs(logged_in_user: User, isolated_test_database) -> None:
+    """Test that freeze times page shows freeze time configurations."""
+    # Create test freeze time config
+    with Session(isolated_test_database) as session:
+        config = FreezeTimeConfig(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=12,
+            created_by=1,
+        )
+        session.add(config)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+
+    # Should see the config
+    await logged_in_user.should_see("12 Monate")
+
+
+async def test_freeze_times_page_groups_by_item_type(logged_in_user: User, isolated_test_database) -> None:
+    """Test that freeze time configs are grouped by item type."""
+    # Create test freeze time configs for different item types
+    with Session(isolated_test_database) as session:
+        config1 = FreezeTimeConfig(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=12,
+            created_by=1,
+        )
+        config2 = FreezeTimeConfig(
+            item_type=ItemType.PURCHASED_THEN_FROZEN,
+            freeze_time_months=6,
+            created_by=1,
+        )
+        session.add(config1)
+        session.add(config2)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+
+    # Should see item type headers (German labels)
+    await logged_in_user.should_see("Selbst eingefroren")
+    await logged_in_user.should_see("Frisch gekauft, eingefroren")
+
+
+async def test_freeze_times_page_shows_category_specific_configs(
+    logged_in_user: User, isolated_test_database
+) -> None:
+    """Test that category-specific configs are displayed with category name."""
+    with Session(isolated_test_database) as session:
+        category = Category(
+            name="Fleisch",
+            created_by=1,
+        )
+        session.add(category)
+        session.commit()
+        session.refresh(category)
+
+        config = FreezeTimeConfig(
+            category_id=category.id,
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=6,
+            created_by=1,
+        )
+        session.add(config)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+
+    # Should see category name
+    await logged_in_user.should_see("Fleisch")
+    await logged_in_user.should_see("6 Monate")
+
+
+async def test_freeze_times_page_shows_empty_state(logged_in_user: User) -> None:
+    """Test that freeze times page shows message when no configs exist."""
+    await logged_in_user.open("/admin/freeze-times")
+
+    # Should see empty state message
+    await logged_in_user.should_see("Keine Gefrierzeit-Konfigurationen vorhanden")
+
+
+# =============================================================================
+# CRUD Tests
+# =============================================================================
+
+
+async def test_freeze_times_page_has_add_button(logged_in_user: User) -> None:
+    """Test that freeze times page has a 'Neu' button for creating new configs."""
+    await logged_in_user.open("/admin/freeze-times")
+    await logged_in_user.should_see("Neu")
+
+
+async def test_add_button_opens_create_dialog(logged_in_user: User) -> None:
+    """Test that clicking 'Neu' button opens a create dialog."""
+    await logged_in_user.open("/admin/freeze-times")
+    logged_in_user.find("Neu").click()
+    await logged_in_user.should_see("Neue Gefrierzeit-Konfiguration")
+
+
+async def test_config_card_has_edit_button(logged_in_user: User, isolated_test_database) -> None:
+    """Test that config cards have edit buttons."""
+    with Session(isolated_test_database) as session:
+        config = FreezeTimeConfig(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=12,
+            created_by=1,
+        )
+        session.add(config)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+    await logged_in_user.should_see("edit")
+
+
+async def test_config_card_has_delete_button(logged_in_user: User, isolated_test_database) -> None:
+    """Test that config cards have delete buttons."""
+    with Session(isolated_test_database) as session:
+        config = FreezeTimeConfig(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=12,
+            created_by=1,
+        )
+        session.add(config)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+    await logged_in_user.should_see("delete")
+
+
+async def test_delete_button_opens_confirmation_dialog(logged_in_user: User, isolated_test_database) -> None:
+    """Test that clicking delete button opens confirmation dialog."""
+    with Session(isolated_test_database) as session:
+        config = FreezeTimeConfig(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            freeze_time_months=12,
+            created_by=1,
+        )
+        session.add(config)
+        session.commit()
+
+    await logged_in_user.open("/admin/freeze-times")
+    logged_in_user.find("delete").click()
+    await logged_in_user.should_see("Löschen bestätigen")

--- a/tests/test_ui/test_settings.py
+++ b/tests/test_ui/test_settings.py
@@ -1,174 +1,59 @@
-"""UI Tests for Settings Page - Gefrierzeit-Konfiguration."""
+"""UI Tests for Settings Page - Admin Navigation and Smart Defaults.
 
-from app.models.category import Category
-from app.models.freeze_time_config import FreezeTimeConfig
-from app.models.freeze_time_config import ItemType
+Issue #79: Settings Page aufteilen - Navigation zu Admin-Bereichen.
+Issue #34: Smart Default Zeitfenster konfigurieren.
+"""
+
 from nicegui.testing import User
-from sqlmodel import Session
 
 
 async def test_settings_page_renders_for_admin(logged_in_user: User) -> None:
     """Test that settings page renders correctly for admin users."""
-    # Navigate to settings (already logged in via fixture)
     await logged_in_user.open("/admin/settings")
 
     # Check page elements
     await logged_in_user.should_see("Einstellungen")
-    await logged_in_user.should_see("Gefrierzeit-Konfiguration")
-
-
-async def test_settings_page_shows_freeze_time_configs(logged_in_user: User, isolated_test_database) -> None:
-    """Test that settings page shows freeze time configurations."""
-    # Create test freeze time config
-    with Session(isolated_test_database) as session:
-        config = FreezeTimeConfig(
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=12,
-            created_by=1,  # admin user from fixture
-        )
-        session.add(config)
-        session.commit()
-
-    # Navigate to settings (already logged in via fixture)
-    await logged_in_user.open("/admin/settings")
-
-    # Should see the config
-    await logged_in_user.should_see("12 Monate")
-
-
-async def test_settings_page_groups_by_item_type(logged_in_user: User, isolated_test_database) -> None:
-    """Test that freeze time configs are grouped by item type."""
-    # Create test freeze time configs for different item types
-    with Session(isolated_test_database) as session:
-        # Global config for homemade frozen
-        config1 = FreezeTimeConfig(
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=12,
-            created_by=1,
-        )
-        # Global config for purchased then frozen
-        config2 = FreezeTimeConfig(
-            item_type=ItemType.PURCHASED_THEN_FROZEN,
-            freeze_time_months=6,
-            created_by=1,
-        )
-        session.add(config1)
-        session.add(config2)
-        session.commit()
-
-    # Navigate to settings (already logged in via fixture)
-    await logged_in_user.open("/admin/settings")
-
-    # Should see item type headers (German labels)
-    await logged_in_user.should_see("Selbst eingefroren")  # HOMEMADE_FROZEN
-    await logged_in_user.should_see("Frisch gekauft, eingefroren")  # PURCHASED_THEN_FROZEN
-
-
-async def test_settings_page_shows_category_specific_configs(logged_in_user: User, isolated_test_database) -> None:
-    """Test that category-specific configs are displayed with category name."""
-    # Create test category and config
-    with Session(isolated_test_database) as session:
-        category = Category(
-            name="Fleisch",
-            created_by=1,
-        )
-        session.add(category)
-        session.commit()
-        session.refresh(category)
-
-        config = FreezeTimeConfig(
-            category_id=category.id,
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=6,
-            created_by=1,
-        )
-        session.add(config)
-        session.commit()
-
-    # Navigate to settings (already logged in via fixture)
-    await logged_in_user.open("/admin/settings")
-
-    # Should see category name
-    await logged_in_user.should_see("Fleisch")
-    await logged_in_user.should_see("6 Monate")
 
 
 async def test_settings_page_requires_auth(user: User) -> None:
     """Test that unauthenticated users are redirected to login."""
-    # Try to access settings without login
     await user.open("/admin/settings")
-    # Should redirect to login
     await user.should_see("Anmelden")
 
 
-async def test_settings_page_shows_empty_state(logged_in_user: User) -> None:
-    """Test that settings page shows message when no configs exist."""
-    # Navigate to settings (already logged in, no configs created)
-    await logged_in_user.open("/admin/settings")
-
-    # Should see empty state message
-    await logged_in_user.should_see("Keine Gefrierzeit-Konfigurationen vorhanden")
-
-
 # =============================================================================
-# CRUD Tests (Issue #33)
+# Admin Navigation Tests (Issue #79)
 # =============================================================================
 
 
-async def test_settings_page_has_add_button(logged_in_user: User) -> None:
-    """Test that settings page has a 'Neu' button for creating new configs."""
+async def test_settings_page_shows_admin_navigation(logged_in_user: User) -> None:
+    """Test that settings page shows admin navigation section."""
     await logged_in_user.open("/admin/settings")
-    await logged_in_user.should_see("Neu")
+    await logged_in_user.should_see("Verwaltung")
 
 
-async def test_add_button_opens_create_dialog(logged_in_user: User) -> None:
-    """Test that clicking 'Neu' button opens a create dialog."""
+async def test_settings_page_shows_categories_link(logged_in_user: User) -> None:
+    """Test that settings page has link to categories."""
     await logged_in_user.open("/admin/settings")
-    logged_in_user.find("Neu").click()
-    await logged_in_user.should_see("Neue Gefrierzeit-Konfiguration")
+    await logged_in_user.should_see("Kategorien")
 
 
-async def test_config_card_has_edit_button(logged_in_user: User, isolated_test_database) -> None:
-    """Test that config cards have edit buttons."""
-    with Session(isolated_test_database) as session:
-        config = FreezeTimeConfig(
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=12,
-            created_by=1,
-        )
-        session.add(config)
-        session.commit()
+async def test_settings_page_shows_locations_link(logged_in_user: User) -> None:
+    """Test that settings page has link to locations."""
     await logged_in_user.open("/admin/settings")
-    await logged_in_user.should_see("edit")
+    await logged_in_user.should_see("Lagerorte")
 
 
-async def test_config_card_has_delete_button(logged_in_user: User, isolated_test_database) -> None:
-    """Test that config cards have delete buttons."""
-    with Session(isolated_test_database) as session:
-        config = FreezeTimeConfig(
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=12,
-            created_by=1,
-        )
-        session.add(config)
-        session.commit()
+async def test_settings_page_shows_users_link(logged_in_user: User) -> None:
+    """Test that settings page has link to users."""
     await logged_in_user.open("/admin/settings")
-    await logged_in_user.should_see("delete")
+    await logged_in_user.should_see("Benutzer")
 
 
-async def test_delete_button_opens_confirmation_dialog(logged_in_user: User, isolated_test_database) -> None:
-    """Test that clicking delete button opens confirmation dialog."""
-    with Session(isolated_test_database) as session:
-        config = FreezeTimeConfig(
-            item_type=ItemType.HOMEMADE_FROZEN,
-            freeze_time_months=12,
-            created_by=1,
-        )
-        session.add(config)
-        session.commit()
+async def test_settings_page_shows_freeze_times_link(logged_in_user: User) -> None:
+    """Test that settings page has link to freeze times."""
     await logged_in_user.open("/admin/settings")
-    logged_in_user.find("delete").click()
-    await logged_in_user.should_see("Löschen bestätigen")
+    await logged_in_user.should_see("Gefrierzeiten")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Settings-Seite zeigt jetzt Navigations-Links zu Admin-Bereichen:
  - Kategorien (`/admin/categories`)
  - Lagerorte (`/admin/locations`)
  - Benutzer (`/admin/users`)
  - Gefrierzeiten (`/admin/freeze-times`)
- Gefrierzeit-Konfiguration in neue Seite `/admin/freeze-times` ausgelagert
- Smart Default Einstellungen bleiben auf Settings-Seite
- Mobile-First Design mit Cards für Navigation

## Test plan
- [x] Settings-Page zeigt "Verwaltung" Navigation
- [x] Links zu Kategorien, Lagerorte, Benutzer, Gefrierzeiten vorhanden
- [x] Smart Default Einstellungen weiterhin verfügbar
- [x] Neue Freeze-Times-Seite funktioniert wie zuvor
- [x] 11 Tests für Settings-Seite
- [x] 11 Tests für Freeze-Times-Seite
- [x] 306 Tests insgesamt bestanden

closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)