### PR TITLE
refactor: Einstellungsseiten auf gleiche maximale Breite wie Wizard begrenzen

### DIFF
--- a/app/ui/components/bottom_nav.py
+++ b/app/ui/components/bottom_nav.py
@@ -55,6 +55,7 @@ def create_mobile_page_container() -> Any:
     """Create container for mobile page with bottom navigation spacing.
 
     Returns the column container that should be used for page content.
+    Uses max-width: 800px for consistent layout across all pages (Issue #81).
     """
-    # Main content area with padding for bottom nav (56px + 16px spacing)
-    return ui.column().classes("w-full p-4").style("padding-bottom: 72px")
+    # Main content area with max-width for desktop and padding for bottom nav (56px + 16px spacing)
+    return ui.column().classes("w-full mx-auto p-4").style("max-width: 800px; padding-bottom: 72px")

--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -514,9 +514,8 @@ def add_item() -> None:
         ui.label("Artikel erfassen").classes("text-h5 font-bold text-primary")
         ui.button(icon="close", on_click=lambda: ui.navigate.to("/dashboard")).props("flat round color=gray-7")
 
-    # Main content container with max-width for desktop
-    with ui.column().classes("w-full mx-auto").style("max-width: 800px"):
-        content_container = create_mobile_page_container()
+    # Main content container (max-width handled by create_mobile_page_container)
+    content_container = create_mobile_page_container()
     with content_container:
         # Progress Indicator
         ui.label("Schritt 1 von 3").classes("text-sm text-gray-600 mb-4")


### PR DESCRIPTION
## Summary
- Update `create_mobile_page_container()` to include `max-width: 800px` and `mx-auto` classes
- Remove redundant outer wrapper from `add_item.py` (wizard)
- All pages using `create_mobile_page_container` now have consistent layout width

## Akzeptanzkriterien
- [x] Einstellungs-Übersichtsseite verwendet gleiche max-width wie Wizard
- [x] Einstellungs-Detailseiten verwenden gleiche max-width wie Wizard
- [x] Konsistentes Layout auf allen Bildschirmgrößen

## Test plan
- [x] All existing tests pass (347 passed)
- [x] mypy type check passes
- [x] ruff lint/format passes

closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)