### PR TITLE
fix: Weiter-Button auf Wizard Seite 1 validiert beim Laden

### DIFF
--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -581,5 +581,8 @@ def add_item() -> None:
                 .style("min-height: 48px")
             )
 
+        # Initial validation to set button state based on smart defaults
+        update_validation()
+
     # Bottom Navigation
     create_bottom_nav(current_page="add")


### PR DESCRIPTION
## Summary
- `update_validation()` wird jetzt beim initialen Laden der Seite aufgerufen
- Der Button-State wird korrekt basierend auf Smart Defaults aktualisiert
- Behebt das visuelle Problem, dass der Button immer ausgegraut erschien

## Ursache
Der Button wurde initial mit `disabled` erstellt (Zeile 578-581), aber `update_validation()` wurde beim Seitenaufruf nicht aufgerufen. In `show_step1()` (beim Zurück-Navigieren) wurde es bereits korrekt aufgerufen.

closes #94

## Test plan
- [x] Seite "Erfassen" öffnen
- [x] Alle Pflichtfelder ausfüllen (Name, Typ, Menge, Einheit)
- [x] Button sollte nun aktiv werden (nicht mehr ausgegraut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)