### PR TITLE
fix: Speichern & Nächster Button funktioniert jetzt

### DIFF
--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -35,8 +35,8 @@ SMART_DEFAULTS_KEY = "last_item_entry"
 @require_auth
 def add_item() -> None:
     """3-Schritt-Wizard für schnelle Artikel-Erfassung."""
-    # Load smart defaults from browser storage
-    last_entry = app.storage.browser.get(SMART_DEFAULTS_KEY)
+    # Load smart defaults from user storage
+    last_entry = app.storage.user.get(SMART_DEFAULTS_KEY)
 
     # Apply smart defaults with time windows
     default_item_type = get_default_item_type(last_entry, window_minutes=30)
@@ -498,7 +498,7 @@ def add_item() -> None:
             category_ids=form_data.get("category_ids"),
             best_before_date_str=best_before_str,
         )
-        app.storage.browser[SMART_DEFAULTS_KEY] = smart_defaults
+        app.storage.user[SMART_DEFAULTS_KEY] = smart_defaults
 
         # Show success notification
         ui.notify(f"✅ {product_name} gespeichert!", type="positive")

--- a/app/ui/smart_defaults.py
+++ b/app/ui/smart_defaults.py
@@ -35,7 +35,7 @@ def create_smart_defaults_dict(
         best_before_date_str: Best before date as string (DD.MM.YYYY format).
 
     Returns:
-        Dictionary suitable for storing in app.storage.browser.
+        Dictionary suitable for storing in app.storage.user.
     """
     return {
         "timestamp": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary
- `app.storage.browser` kann nicht in Event-Handlern geschrieben werden (Response bereits gesendet)
- Fix: `app.storage.user` verwenden für Smart Defaults Storage
- Beide Stellen geändert: Lesen und Schreiben der Smart Defaults

## Ursache
```
TypeError: the response to the browser has already been built, so modifications cannot be sent back anymore
```

## Test plan
- [x] Unit Tests bestanden (347 passed)
- [x] Manuell getestet: "Speichern & Nächster" speichert und navigiert zurück

closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)