### PR TITLE
test: Login-Page E2E Tests mit Playwright

### DIFF
--- a/tests/test_e2e/__init__.py
+++ b/tests/test_e2e/__init__.py
@@ -4,8 +4,15 @@ Diese Tests verwenden Playwright für echte Browser-Automatisierung.
 Sie sind langsamer als die NiceGUI User Fixture Tests, können aber
 komplexe Workflows testen die echtes Browser-Verhalten brauchen.
 
+WICHTIG: E2E Tests müssen SEPARAT von den regulären Tests laufen!
+         Sie starten echte Server-Prozesse und können mit dem
+         NiceGUI Testing Plugin kollidieren.
+
 Verwendung:
-    # Alle E2E Tests ausführen
+    # Reguläre Tests (ohne E2E)
+    uv run pytest tests/ --ignore=tests/test_e2e/
+
+    # E2E Tests separat ausführen
     uv run pytest tests/test_e2e/
 
     # Mit sichtbarem Browser

--- a/tests/test_e2e/_server.py
+++ b/tests/test_e2e/_server.py
@@ -1,0 +1,74 @@
+"""Standalone E2E Test Server.
+
+Dieses Script wird als separater Prozess gestartet für E2E Tests.
+Es bekommt den Port als Command-Line Argument.
+"""
+
+import os
+from pathlib import Path
+import sys
+
+
+# Projekt-Root zum Python-Pfad hinzufügen
+# (tests/test_e2e/_server.py -> Projekt-Root ist 3 Ebenen höher)
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def main() -> None:
+    """Starte den Test-Server."""
+    if len(sys.argv) != 2:
+        print("Usage: python _server.py <port>", file=sys.stderr)
+        sys.exit(1)
+
+    port = int(sys.argv[1])
+
+    # Setze Umgebungsvariablen für Test-Modus
+    # WICHTIG: TESTING NICHT setzen, da sonst NiceGUI Test-Modus aktiviert wird
+    # und NICEGUI_SCREEN_TEST_PORT erwartet
+    os.environ["SECRET_KEY"] = "test-secret-key-for-e2e-tests"
+    os.environ["FUELLHORN_SECRET"] = "test-fuellhorn-secret-for-e2e-tests"
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+    # Entferne NiceGUI Test-Mode Variablen die von pytest geerbt werden könnten
+    for var in list(os.environ.keys()):
+        if var.startswith("NICEGUI_") or var == "TESTING":
+            del os.environ[var]
+
+    # Importiere die App erst hier damit Umgebungsvariablen wirken
+    # HINWEIS: test_pages wird NICHT importiert da wir echte UI testen
+    import app.api.health as _api_health  # noqa: F401
+    from app.database import create_db_and_tables
+    from app.database import get_session
+    from app.models import User
+    import app.ui.pages as _pages  # noqa: F401
+    from nicegui import ui
+
+    # Datenbank initialisieren (in-memory SQLite)
+    create_db_and_tables()
+
+    # Admin-User erstellen
+    with next(get_session()) as session:
+        admin = User(
+            username="admin",
+            email="admin@test.com",
+            is_active=True,
+            role="admin",
+        )
+        admin.set_password("admin")  # Einfaches Passwort für E2E Tests
+        session.add(admin)
+        session.commit()
+
+    # Server starten
+    ui.run(
+        host="127.0.0.1",
+        port=port,
+        title="Füllhorn - E2E Test",
+        storage_secret="test-storage-secret",
+        reload=False,
+        show=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_e2e/test_login.py
+++ b/tests/test_e2e/test_login.py
@@ -1,0 +1,63 @@
+"""E2E Tests für die Login-Seite mit Playwright.
+
+Diese Tests prüfen die Login-Funktionalität im echten Browser:
+- Login-Seite rendert korrekt
+- Login mit gültigen Credentials
+- Login mit ungültigen Credentials zeigt Fehler
+"""
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+
+def test_login_page_renders_correctly(page: Page, live_server: str) -> None:
+    """Test: Login-Seite rendert alle UI-Elemente korrekt."""
+    page.goto(f"{live_server}/login")
+
+    # Titel und Untertitel prüfen
+    expect(page.get_by_text("Füllhorn")).to_be_visible()
+    expect(page.get_by_text("Lebensmittelvorrats-Verwaltung")).to_be_visible()
+
+    # Formular-Elemente prüfen
+    expect(page.get_by_label("Benutzername")).to_be_visible()
+    expect(page.get_by_label("Passwort")).to_be_visible()
+    # Checkbox hat den vollen Text "Angemeldet bleiben (30 Tage)"
+    expect(page.get_by_text("Angemeldet bleiben")).to_be_visible()
+    expect(page.get_by_role("button", name="Anmelden")).to_be_visible()
+
+
+def test_login_with_valid_credentials(page: Page, live_server: str) -> None:
+    """Test: Login mit gültigen Credentials leitet zum Dashboard weiter."""
+    page.goto(f"{live_server}/login")
+
+    # Credentials eingeben (admin/admin wird von live_server Fixture erstellt)
+    page.get_by_label("Benutzername").fill("admin")
+    page.get_by_label("Passwort").fill("admin")
+
+    # Login Button klicken
+    page.get_by_role("button", name="Anmelden").click()
+
+    # Warten auf Redirect zum Dashboard (mit Timeout)
+    page.wait_for_url(f"{live_server}/dashboard", timeout=10000)
+
+    # Verifizieren dass wir auf dem Dashboard sind
+    # (URL-Check ist der primäre Erfolgsindikator)
+    assert "/dashboard" in page.url
+
+
+def test_login_with_invalid_credentials(page: Page, live_server: str) -> None:
+    """Test: Login mit ungültigen Credentials zeigt Fehlermeldung."""
+    page.goto(f"{live_server}/login")
+
+    # Ungültige Credentials eingeben
+    page.get_by_label("Benutzername").fill("admin")
+    page.get_by_label("Passwort").fill("wrong-password")
+
+    # Login Button klicken
+    page.get_by_role("button", name="Anmelden").click()
+
+    # Fehler-Notification prüfen (Text aus auth_service.py)
+    expect(page.get_by_text("Username oder Passwort falsch")).to_be_visible(timeout=5000)
+
+    # URL sollte weiterhin /login sein (kein Redirect)
+    assert "/login" in page.url


### PR DESCRIPTION
## Summary
- 3 Playwright E2E Tests für die Login-Seite implementiert
- Server-Infrastruktur für E2E Tests optimiert (subprocess statt multiprocessing)
- Dokumentation für separate Test-Ausführung hinzugefügt

## Tests

| Test | Beschreibung |
|------|--------------|
| `test_login_page_renders_correctly` | Prüft UI-Elemente: Titel, Inputs, Button |
| `test_login_with_valid_credentials` | Login mit admin/admin → Dashboard Redirect |
| `test_login_with_invalid_credentials` | Falsches Passwort → Fehlermeldung |

## Technische Details
- `_server.py`: Separates Server-Script mit sauberer Umgebung (ohne NiceGUI Test-Mode)
- `conftest.py`: subprocess.Popen statt multiprocessing.Process
- E2E Tests müssen separat von regulären Tests laufen

## Test plan
- [x] 3 E2E Tests grün: `uv run pytest tests/test_e2e/ -v`
- [x] 356 reguläre Tests grün: `uv run pytest tests/ --ignore=tests/test_e2e/`
- [x] mypy: Success
- [x] ruff: All checks passed

closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)