### PR TITLE
feat: Item Model: category_id FK hinzufügen und ItemType Enum verschieben

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,9 +7,9 @@ from .category import Category
 from .category_shelf_life import CategoryShelfLife
 from .category_shelf_life import StorageType
 from .freeze_time_config import FreezeTimeConfig
-from .freeze_time_config import ItemType
 from .item import Item
 from .item import ItemCategory
+from .item import ItemType
 from .location import Location
 from .location import LocationType
 from .system_settings import SystemSettings

--- a/app/models/freeze_time_config.py
+++ b/app/models/freeze_time_config.py
@@ -1,23 +1,10 @@
 """FreezeTimeConfig model for freeze time calculation rules."""
 
+from .item import ItemType
 from datetime import datetime
-from enum import Enum
 from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 from sqlmodel import SQLModel
-
-
-class ItemType(str, Enum):
-    """Item type for expiry calculation.
-
-    Based on UI_KONZEPT.md - reflects actual user workflow for food storage.
-    """
-
-    PURCHASED_FRESH = "purchased_fresh"  # Frisch eingekauft
-    PURCHASED_FROZEN = "purchased_frozen"  # TK-Ware gekauft
-    PURCHASED_THEN_FROZEN = "purchased_then_frozen"  # Frisch gekauft → eingefroren
-    HOMEMADE_FROZEN = "homemade_frozen"  # Selbst eingefroren (Ernte/Reste)
-    HOMEMADE_PRESERVED = "homemade_preserved"  # Selbst eingemacht
 
 
 class FreezeTimeConfig(SQLModel, table=True):

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -1,10 +1,23 @@
 """Item model for inventory management."""
 
-from .freeze_time_config import ItemType
 from datetime import date
 from datetime import datetime
+from enum import Enum
 from sqlmodel import Field
 from sqlmodel import SQLModel
+
+
+class ItemType(str, Enum):
+    """Item type for expiry calculation.
+
+    Based on UI_KONZEPT.md - reflects actual user workflow for food storage.
+    """
+
+    PURCHASED_FRESH = "purchased_fresh"  # Frisch eingekauft
+    PURCHASED_FROZEN = "purchased_frozen"  # TK-Ware gekauft
+    PURCHASED_THEN_FROZEN = "purchased_then_frozen"  # Frisch gekauft → eingefroren
+    HOMEMADE_FROZEN = "homemade_frozen"  # Selbst eingefroren (Ernte/Reste)
+    HOMEMADE_PRESERVED = "homemade_preserved"  # Selbst eingemacht
 
 
 class Item(SQLModel, table=True):
@@ -24,6 +37,7 @@ class Item(SQLModel, table=True):
     unit: str  # e.g., "kg", "L", "pieces"
     item_type: ItemType
     location_id: int = Field(foreign_key="location.id")
+    category_id: int | None = Field(default=None, foreign_key="category.id")
     notes: str | None = Field(default=None)
     is_consumed: bool = Field(default=False)
     created_at: datetime = Field(default_factory=datetime.now)

--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -1,9 +1,9 @@
 """Item service - Business logic for item management."""
 
 from ..models.category import Category
-from ..models.freeze_time_config import ItemType
 from ..models.item import Item
 from ..models.item import ItemCategory
+from ..models.item import ItemType
 from . import expiry_calculator
 from . import freeze_time_service
 from datetime import date
@@ -24,6 +24,7 @@ def create_item(
     freeze_date: date | None = None,
     notes: str | None = None,
     category_ids: list[int] | None = None,
+    category_id: int | None = None,
 ) -> Item:
     """Create a new item with automatic expiry calculation.
 
@@ -38,7 +39,8 @@ def create_item(
         created_by: User ID who created the item
         freeze_date: Date when item was frozen (required for FROZEN items)
         notes: Optional notes
-        category_ids: Optional list of category IDs to assign
+        category_ids: Optional list of category IDs to assign (many-to-many, deprecated)
+        category_id: Optional category ID (single FK, new approach)
 
     Returns:
         Created item
@@ -70,6 +72,7 @@ def create_item(
         unit=unit,
         item_type=item_type,
         location_id=location_id,
+        category_id=category_id,
         notes=notes,
         created_by=created_by,
     )

--- a/tests/test_services/test_item_service.py
+++ b/tests/test_services/test_item_service.py
@@ -88,6 +88,62 @@ def test_create_item_with_categories(session: Session, test_admin: User) -> None
     assert cat2.id in [c.id for c in categories]
 
 
+def test_create_item_with_category_id(session: Session, test_admin: User) -> None:
+    """Test creating an item with the new category_id field."""
+    location = location_service.create_location(
+        session=session,
+        name="Kühlschrank",
+        location_type=LocationType.CHILLED,
+        created_by=test_admin.id,
+    )
+    category = category_service.create_category(
+        session=session,
+        name="Milchprodukte",
+        created_by=test_admin.id,
+    )
+
+    assert category.id is not None
+
+    item = item_service.create_item(
+        session=session,
+        product_name="Joghurt",
+        best_before_date=date(2024, 12, 15),
+        quantity=1,
+        unit="Becher",
+        item_type=ItemType.PURCHASED_FRESH,
+        location_id=location.id,
+        created_by=test_admin.id,
+        category_id=category.id,
+    )
+
+    assert item.id is not None
+    assert item.category_id == category.id
+
+
+def test_create_item_without_category_id(session: Session, test_admin: User) -> None:
+    """Test creating an item without category_id (should be None)."""
+    location = location_service.create_location(
+        session=session,
+        name="Kühlschrank",
+        location_type=LocationType.CHILLED,
+        created_by=test_admin.id,
+    )
+
+    item = item_service.create_item(
+        session=session,
+        product_name="Butter",
+        best_before_date=date(2024, 12, 20),
+        quantity=1,
+        unit="Packung",
+        item_type=ItemType.PURCHASED_FRESH,
+        location_id=location.id,
+        created_by=test_admin.id,
+    )
+
+    assert item.id is not None
+    assert item.category_id is None
+
+
 def test_get_all_items(session: Session, test_admin: User) -> None:
     """Test getting all items."""
     location = location_service.create_location(


### PR DESCRIPTION
## Summary

- ItemType Enum von `freeze_time_config.py` nach `item.py` verschoben (Vorbereitung für #110)
- `category_id: int | None` als FK zu `category.id` zum Item Model hinzugefügt (nullable für Übergang)
- `item_service.create_item()` um `category_id` Parameter erweitert
- Unit-Tests für das neue `category_id` Feld hinzugefügt

## Test plan

- [x] Alle bestehenden Tests laufen (358 passed)
- [x] Neue Tests für `category_id` Feld hinzugefügt
- [x] mypy: keine Fehler
- [x] ruff: keine Fehler

closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)