### PR TITLE
ci: E2E Tests mit Playwright in CI hinzufügen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,34 @@ jobs:
           path: .coverage.ui
           include-hidden-files: true
 
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install Playwright Chromium
+        run: uv run playwright install chromium
+
+      - name: Run E2E tests
+        run: uv run pytest tests/test_e2e/ -v
+        env:
+          SECRET_KEY: test-secret-key-for-ci-only
+          FUELLHORN_SECRET: test-fuellhorn-secret-for-ci-only
+
   coverage:
     name: Combine & check coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Neuer CI Job `test-e2e` für Playwright Browser-Tests
- Chromium-Installation via `playwright install chromium`
- E2E Tests laufen parallel zu Unit/UI Tests (nicht sequentiell abhängig)

## Details

Der neue Job:
- Installiert Python 3.14 und Dependencies via uv
- Installiert Playwright Chromium Browser
- Führt `tests/test_e2e/` aus
- 10 Minuten Timeout

## Test plan
- [x] CI Job läuft erfolgreich durch
- [x] E2E Tests (Login-Page) bestehen in CI

closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)