### PR TITLE
refactor: Service: category_service anpassen - freeze_time_months entfernen

### DIFF
--- a/app/services/category_service.py
+++ b/app/services/category_service.py
@@ -10,7 +10,6 @@ def create_category(
     name: str,
     created_by: int,
     color: str | None = None,
-    freeze_time_months: int | None = None,
 ) -> Category:
     """Create a new category.
 
@@ -19,7 +18,6 @@ def create_category(
         name: Category name (case-insensitive unique)
         created_by: User ID who created the category
         color: Hex color code (e.g., "#FF5733")
-        freeze_time_months: Default freeze time in months (1-24)
 
     Returns:
         Created category
@@ -39,7 +37,6 @@ def create_category(
         name=name,
         created_by=created_by,
         color=color,
-        freeze_time_months=freeze_time_months,
     )
 
     session.add(category)
@@ -87,7 +84,6 @@ def update_category(
     id: int,
     name: str | None = None,
     color: str | None = None,
-    freeze_time_months: int | None = None,
 ) -> Category:
     """Update category.
 
@@ -96,7 +92,6 @@ def update_category(
         id: Category ID
         name: New name (case-insensitive unique)
         color: New color code
-        freeze_time_months: New freeze time in months
 
     Returns:
         Updated category
@@ -119,9 +114,6 @@ def update_category(
 
     if color is not None:
         category.color = color
-
-    if freeze_time_months is not None:
-        category.freeze_time_months = freeze_time_months
 
     session.add(category)
     session.commit()

--- a/app/ui/pages/categories.py
+++ b/app/ui/pages/categories.py
@@ -202,7 +202,6 @@ def _open_edit_dialog(
                             id=category_id,
                             name=name if name != current_name else None,
                             color=color,
-                            freeze_time_months=current_freeze_time,
                         )
                     ui.notify(f"Kategorie '{name}' aktualisiert", type="positive")
                     dialog.close()

--- a/tests/test_services/test_category_service.py
+++ b/tests/test_services/test_category_service.py
@@ -15,13 +15,11 @@ def test_create_category(session: Session, test_admin: User) -> None:
         name="Gemüse",
         created_by=test_admin.id,
         color="#4CAF50",
-        freeze_time_months=12,
     )
 
     assert category.id is not None
     assert category.name == "Gemüse"
     assert category.color == "#4CAF50"
-    assert category.freeze_time_months == 12
     assert category.created_by == test_admin.id
 
 
@@ -79,13 +77,11 @@ def test_update_category(session: Session, test_admin: User) -> None:
         id=category.id,
         name="Brot & Backwaren",
         color="#FFEB3B",
-        freeze_time_months=6,
     )
 
     assert updated.id == category.id
     assert updated.name == "Brot & Backwaren"
     assert updated.color == "#FFEB3B"
-    assert updated.freeze_time_months == 6
 
 
 def test_update_category_duplicate_name_fails(session: Session, test_admin: User) -> None:


### PR DESCRIPTION
## Summary

- `freeze_time_months` Parameter aus `create_category()` entfernt
- `freeze_time_months` Parameter aus `update_category()` entfernt
- UI-Aufruf von `update_category()` in `categories.py` angepasst
- Tests aktualisiert

Haltbarkeiten werden jetzt über `CategoryShelfLife` verwaltet, nicht mehr direkt auf der Kategorie.

## Test plan

- [x] Service-Tests laufen (104 passed)
- [x] Alle Tests laufen (349 passed, 2 skipped)
- [x] mypy: keine Fehler
- [x] ruff: keine Fehler

closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)