### PR TITLE
feat: Service: expiry_calculator (neue Min/Max Logik)

### DIFF
--- a/app/services/expiry_calculator.py
+++ b/app/services/expiry_calculator.py
@@ -1,5 +1,6 @@
 """Expiry calculator - Calculate expiry dates and status for items."""
 
+from ..models.category_shelf_life import StorageType
 from ..models.freeze_time_config import ItemType
 from datetime import date
 from dateutil.relativedelta import relativedelta
@@ -8,6 +9,123 @@ from typing import Literal
 
 # Type alias for expiry status
 ExpiryStatus = Literal["critical", "warning", "ok"]
+
+
+def get_storage_type_for_item_type(item_type: ItemType) -> StorageType | None:
+    """Get the storage type for shelf life calculation.
+
+    Maps item types to storage types for looking up CategoryShelfLife data.
+    Returns None for item types that use best_before_date directly (MHD).
+
+    Args:
+        item_type: The type of item
+
+    Returns:
+        StorageType for shelf life lookup, or None if item uses MHD directly
+    """
+    if item_type in [ItemType.PURCHASED_THEN_FROZEN, ItemType.HOMEMADE_FROZEN]:
+        return StorageType.FROZEN
+    elif item_type == ItemType.HOMEMADE_PRESERVED:
+        return StorageType.AMBIENT
+    return None  # PURCHASED_FRESH, PURCHASED_FROZEN use MHD directly
+
+
+def calculate_expiry_dates(
+    item_type: ItemType,
+    base_date: date,
+    months_min: int,
+    months_max: int,
+) -> tuple[date, date]:
+    """Calculate optimal and maximum expiry dates.
+
+    Uses months_min for optimal consumption date and months_max for
+    maximum storage date.
+
+    Args:
+        item_type: Type of item (not currently used, for future extension)
+        base_date: The base date (freeze_date or production_date)
+        months_min: Minimum recommended storage time in months
+        months_max: Maximum recommended storage time in months
+
+    Returns:
+        Tuple of (optimal_date, max_date)
+    """
+    optimal_date = base_date + relativedelta(months=months_min)
+    max_date = base_date + relativedelta(months=months_max)
+    return (optimal_date, max_date)
+
+
+def get_expiry_status_minmax(
+    optimal_date: date | None,
+    max_date: date | None,
+    best_before_date: date | None = None,
+) -> ExpiryStatus:
+    """Get expiry status based on optimal and maximum dates.
+
+    Status logic:
+    - ok: today < optimal_date
+    - warning: optimal_date <= today < max_date - 3 days
+    - critical: today >= max_date - 3 days
+
+    If best_before_date is provided (for items with MHD), it takes precedence
+    using the old 3/7 day thresholds.
+
+    Args:
+        optimal_date: Optimal consumption date (from months_min)
+        max_date: Maximum storage date (from months_max)
+        best_before_date: Best before date from package (MHD)
+
+    Returns:
+        ExpiryStatus: "critical", "warning", or "ok"
+    """
+    today = date.today()
+
+    # If best_before_date is provided, use it as the primary date
+    # (for PURCHASED_FRESH, PURCHASED_FROZEN with MHD)
+    if best_before_date is not None:
+        days_until_best_before = (best_before_date - today).days
+        if days_until_best_before < 3:
+            return "critical"
+        elif days_until_best_before <= 7:
+            return "warning"
+        else:
+            return "ok"
+
+    # If only max_date is provided (no optimal)
+    if optimal_date is None and max_date is not None:
+        days_until_max = (max_date - today).days
+        if days_until_max <= 3:
+            return "critical"
+        else:
+            return "ok"
+
+    # If only optimal_date is provided (no max)
+    if max_date is None and optimal_date is not None:
+        days_until_optimal = (optimal_date - today).days
+        if days_until_optimal < 0:
+            return "warning"
+        else:
+            return "ok"
+
+    # Both optimal_date and max_date are None - shouldn't happen but handle gracefully
+    if optimal_date is None or max_date is None:
+        return "ok"
+
+    # Normal case: both optimal and max dates provided
+    # (mypy now knows both are not None due to the check above)
+    days_until_optimal = (optimal_date - today).days
+    days_until_max = (max_date - today).days
+
+    # Critical: within 3 days of max_date (or past it)
+    if days_until_max <= 3:
+        return "critical"
+
+    # Ok: before optimal_date
+    if days_until_optimal > 0:
+        return "ok"
+
+    # Warning: past optimal but more than 3 days before max
+    return "warning"
 
 
 def calculate_expiry_date(

--- a/tests/test_services/test_expiry_calculator_minmax.py
+++ b/tests/test_services/test_expiry_calculator_minmax.py
@@ -1,0 +1,261 @@
+"""Tests for new Min/Max expiry calculator logic.
+
+Tests the new functions for calculating optimal and maximum expiry dates
+based on CategoryShelfLife months_min and months_max values.
+"""
+
+from app.models import ItemType
+from app.models.category_shelf_life import StorageType
+from app.services import expiry_calculator
+from datetime import date
+from datetime import timedelta
+
+
+class TestGetStorageTypeForItemType:
+    """Tests for get_storage_type_for_item_type function."""
+
+    def test_purchased_then_frozen_returns_frozen(self) -> None:
+        """Test: PURCHASED_THEN_FROZEN returns StorageType.FROZEN."""
+        result = expiry_calculator.get_storage_type_for_item_type(ItemType.PURCHASED_THEN_FROZEN)
+        assert result == StorageType.FROZEN
+
+    def test_homemade_frozen_returns_frozen(self) -> None:
+        """Test: HOMEMADE_FROZEN returns StorageType.FROZEN."""
+        result = expiry_calculator.get_storage_type_for_item_type(ItemType.HOMEMADE_FROZEN)
+        assert result == StorageType.FROZEN
+
+    def test_homemade_preserved_returns_ambient(self) -> None:
+        """Test: HOMEMADE_PRESERVED returns StorageType.AMBIENT."""
+        result = expiry_calculator.get_storage_type_for_item_type(ItemType.HOMEMADE_PRESERVED)
+        assert result == StorageType.AMBIENT
+
+    def test_purchased_fresh_returns_none(self) -> None:
+        """Test: PURCHASED_FRESH returns None (uses MHD directly)."""
+        result = expiry_calculator.get_storage_type_for_item_type(ItemType.PURCHASED_FRESH)
+        assert result is None
+
+    def test_purchased_frozen_returns_none(self) -> None:
+        """Test: PURCHASED_FROZEN returns None (uses MHD directly)."""
+        result = expiry_calculator.get_storage_type_for_item_type(ItemType.PURCHASED_FROZEN)
+        assert result is None
+
+
+class TestCalculateExpiryDates:
+    """Tests for calculate_expiry_dates function."""
+
+    def test_calculate_dates_basic(self) -> None:
+        """Test basic expiry date calculation."""
+        base_date = date(2024, 1, 15)
+        months_min = 6
+        months_max = 12
+
+        optimal, maximum = expiry_calculator.calculate_expiry_dates(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            base_date=base_date,
+            months_min=months_min,
+            months_max=months_max,
+        )
+
+        assert optimal == date(2024, 7, 15)  # +6 months
+        assert maximum == date(2025, 1, 15)  # +12 months
+
+    def test_calculate_dates_equal_min_max(self) -> None:
+        """Test when min equals max."""
+        base_date = date(2024, 3, 1)
+        months_min = 9
+        months_max = 9
+
+        optimal, maximum = expiry_calculator.calculate_expiry_dates(
+            item_type=ItemType.PURCHASED_THEN_FROZEN,
+            base_date=base_date,
+            months_min=months_min,
+            months_max=months_max,
+        )
+
+        assert optimal == date(2024, 12, 1)  # +9 months
+        assert maximum == date(2024, 12, 1)  # +9 months (same)
+
+    def test_calculate_dates_end_of_month(self) -> None:
+        """Test with end of month dates (edge case for month arithmetic)."""
+        base_date = date(2024, 1, 31)
+        months_min = 1
+        months_max = 3
+
+        optimal, maximum = expiry_calculator.calculate_expiry_dates(
+            item_type=ItemType.HOMEMADE_PRESERVED,
+            base_date=base_date,
+            months_min=months_min,
+            months_max=months_max,
+        )
+
+        # dateutil.relativedelta handles month-end properly
+        assert optimal == date(2024, 2, 29)  # Feb 29 (leap year 2024)
+        assert maximum == date(2024, 4, 30)  # Apr has 30 days
+
+    def test_calculate_dates_across_year_boundary(self) -> None:
+        """Test calculation across year boundary."""
+        base_date = date(2024, 11, 15)
+        months_min = 3
+        months_max = 6
+
+        optimal, maximum = expiry_calculator.calculate_expiry_dates(
+            item_type=ItemType.HOMEMADE_FROZEN,
+            base_date=base_date,
+            months_min=months_min,
+            months_max=months_max,
+        )
+
+        assert optimal == date(2025, 2, 15)  # +3 months, into 2025
+        assert maximum == date(2025, 5, 15)  # +6 months
+
+
+class TestGetExpiryStatusMinMax:
+    """Tests for new get_expiry_status with optimal/max dates."""
+
+    def test_status_ok_before_optimal(self) -> None:
+        """Test: Status 'ok' when today < optimal_date."""
+        optimal_date = date.today() + timedelta(days=30)
+        max_date = date.today() + timedelta(days=60)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "ok"
+
+    def test_status_warning_at_optimal(self) -> None:
+        """Test: Status 'warning' when today == optimal_date."""
+        optimal_date = date.today()
+        max_date = date.today() + timedelta(days=30)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "warning"
+
+    def test_status_warning_between_optimal_and_critical_zone(self) -> None:
+        """Test: Status 'warning' when optimal <= today < max - 3 days."""
+        optimal_date = date.today() - timedelta(days=5)
+        max_date = date.today() + timedelta(days=10)  # max - 3 = 7 days from now
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "warning"
+
+    def test_status_critical_at_max_minus_3(self) -> None:
+        """Test: Status 'critical' when today >= max_date - 3 days."""
+        optimal_date = date.today() - timedelta(days=20)
+        max_date = date.today() + timedelta(days=3)  # Exactly 3 days
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "critical"
+
+    def test_status_critical_at_max_minus_2(self) -> None:
+        """Test: Status 'critical' when 2 days before max."""
+        optimal_date = date.today() - timedelta(days=20)
+        max_date = date.today() + timedelta(days=2)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "critical"
+
+    def test_status_critical_at_max(self) -> None:
+        """Test: Status 'critical' when today == max_date."""
+        optimal_date = date.today() - timedelta(days=30)
+        max_date = date.today()
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "critical"
+
+    def test_status_critical_past_max(self) -> None:
+        """Test: Status 'critical' when today > max_date."""
+        optimal_date = date.today() - timedelta(days=60)
+        max_date = date.today() - timedelta(days=10)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        assert status == "critical"
+
+    def test_status_with_best_before_date_overrides(self) -> None:
+        """Test: best_before_date takes precedence when provided."""
+        optimal_date = date.today() + timedelta(days=30)  # Would be "ok"
+        max_date = date.today() + timedelta(days=60)
+        best_before = date.today() + timedelta(days=1)  # Very close, should be critical
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+            best_before_date=best_before,
+        )
+
+        # best_before_date is used for items with MHD - should check against it
+        assert status == "critical"
+
+    def test_status_with_none_optimal_uses_max_only(self) -> None:
+        """Test: When optimal_date is None, use max_date only."""
+        max_date = date.today() + timedelta(days=10)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=None,
+            max_date=max_date,
+        )
+
+        # With only max_date, check if within critical zone
+        assert status == "ok"
+
+    def test_status_with_none_max_uses_optimal_only(self) -> None:
+        """Test: When max_date is None, use optimal_date only."""
+        optimal_date = date.today() + timedelta(days=5)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=None,
+        )
+
+        assert status == "ok"
+
+    def test_status_only_best_before(self) -> None:
+        """Test: When only best_before_date is provided."""
+        best_before = date.today() + timedelta(days=2)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=None,
+            max_date=None,
+            best_before_date=best_before,
+        )
+
+        # Uses old logic: < 3 days = critical
+        assert status == "critical"
+
+    def test_status_boundary_at_4_days_before_max(self) -> None:
+        """Test: Exactly 4 days before max should be warning (not critical)."""
+        optimal_date = date.today() - timedelta(days=10)
+        max_date = date.today() + timedelta(days=4)
+
+        status = expiry_calculator.get_expiry_status_minmax(
+            optimal_date=optimal_date,
+            max_date=max_date,
+        )
+
+        # 4 days > 3 days, so should be warning not critical
+        assert status == "warning"


### PR DESCRIPTION
## Summary
- Neue Funktionen für Min/Max Haltbarkeitsberechnung implementiert:
  - `get_storage_type_for_item_type()`: Mappt ItemType auf StorageType für CategoryShelfLife Lookup
  - `calculate_expiry_dates()`: Berechnet optimal_date (months_min) und max_date (months_max)
  - `get_expiry_status_minmax()`: Neuer 3-Stufen-Status (ok/warning/critical) basierend auf optimal und max Datum

## Status-Logik
- **ok**: heute < optimal_date
- **warning**: optimal_date <= heute < max_date - 3 Tage
- **critical**: heute >= max_date - 3 Tage

## Test plan
- [x] 21 Unit-Tests für alle neuen Funktionen
- [x] Tests für Edge Cases (Monatsenden, Jahreswechsel)
- [x] Tests für Status-Grenzen
- [x] Alle 40 expiry_calculator Tests bestanden
- [x] mypy: Keine Fehler
- [x] ruff: Alle Checks bestanden

closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)