### PR TITLE
feat: Wizard Schritt 3 - Lagerorte nach Artikel-Typ filtern

### DIFF
--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -382,12 +382,25 @@ def add_item() -> None:
                     date_info += f" • Eingefroren: {freeze_str}"
                 ui.label(date_info).classes("text-sm")
 
-            # Fetch locations from database
+            # Fetch locations filtered by item type
             with next(get_session()) as session:
-                locations = location_service.get_all_locations(session)
+                locations = location_service.get_locations_for_item_type(session, item_type)
 
             # Location Selection (required)
             ui.label("Lagerort *").classes("text-sm font-medium mb-1")
+
+            if not locations:
+                # Show warning when no matching locations exist
+                if item_type in {
+                    ItemType.PURCHASED_FROZEN,
+                    ItemType.PURCHASED_THEN_FROZEN,
+                    ItemType.HOMEMADE_FROZEN,
+                }:
+                    warning_msg = "Kein Tiefkühl-Lagerort vorhanden. Bitte zuerst einen anlegen."
+                else:
+                    warning_msg = "Kein passender Lagerort (Keller/Kühlschrank) vorhanden."
+                ui.label(warning_msg).classes("text-sm text-red-600 mb-2")
+
             location_options = {loc.id: loc.name for loc in locations}
             location_select = (
                 ui.select(


### PR DESCRIPTION
## Summary

- Implementiert Location-Filterung basierend auf Item-Typ im Wizard Schritt 3
- `purchased_fresh` → nur `chilled`/`ambient` (nicht einfrieren, sonst wäre es purchased_then_frozen)
- `purchased_frozen`, `purchased_then_frozen`, `homemade_frozen` → nur `frozen`
- `homemade_preserved` → nur `chilled`/`ambient` (Eingemachtes nicht einfrieren)
- UX-Hinweise wenn keine passenden Lagerorte vorhanden

## Änderungen

- `app/services/location_service.py`: Neue Funktionen `get_valid_location_types()` und `get_locations_for_item_type()`
- `app/ui/pages/add_item.py`: Wizard Schritt 3 verwendet gefilterte Locations
- Tests für alle 5 Item-Typen

## Test plan

- [x] Unit Tests für `get_valid_location_types()` (5 Item-Typen)
- [x] Integration Tests für `get_locations_for_item_type()` (DB-Filterung)
- [x] mypy type check bestanden
- [x] ruff lint check bestanden

closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)