### PR TITLE
feat: Lagerort als Chips im Wizard auswählen

### DIFF
--- a/app/ui/components/__init__.py
+++ b/app/ui/components/__init__.py
@@ -15,6 +15,7 @@ from .item_card import create_item_card
 from .item_card import get_status_color
 from .item_type_chips import create_item_type_chip_group
 from .item_type_chips import get_item_type_label
+from .location_chips import create_location_chip_group
 from .unit_chips import create_unit_chip_group
 from .unit_chips import get_available_units
 from .user_dropdown import create_user_dropdown
@@ -27,6 +28,7 @@ __all__ = [
     "create_expiry_badge",
     "create_item_card",
     "create_item_type_chip_group",
+    "create_location_chip_group",
     "create_mobile_page_container",
     "create_unit_chip_group",
     "create_user_dropdown",

--- a/app/ui/components/location_chips.py
+++ b/app/ui/components/location_chips.py
@@ -1,0 +1,111 @@
+"""Location Chip Group Component.
+
+A chip-based selection component for choosing storage locations with a radio-button-like
+ring-dot indicator. Designed for mobile-first touch interaction.
+Locations are loaded dynamically from the database.
+"""
+
+from ...models.location import Location
+from collections.abc import Callable
+from collections.abc import Sequence
+from nicegui import ui
+
+
+def create_location_chip_group(
+    locations: Sequence[Location],
+    value: int | None = None,
+    on_change: Callable[[int], None] | None = None,
+) -> ui.element:
+    """Create a chip group for selecting locations.
+
+    Args:
+        locations: List of Location objects from the database
+        value: Initially selected location_id (optional)
+        on_change: Callback when selection changes (receives location_id)
+
+    Returns:
+        The container element with all chips
+    """
+    # Store current selection and chip references
+    current_value: list[int | None] = [value]
+    chip_refs: dict[int, ui.element] = {}
+    dot_refs: dict[int, ui.element] = {}
+
+    def update_chip_styles() -> None:
+        """Update all chips to reflect current selection."""
+        for location_id, chip in chip_refs.items():
+            is_selected = location_id == current_value[0]
+            dot = dot_refs[location_id]
+
+            if is_selected:
+                # Selected state - white outer ring with colored inner dot
+                chip.classes(
+                    remove="bg-gray-100 text-gray-700 hover:bg-gray-200",
+                    add="bg-primary text-white",
+                )
+                dot.style(
+                    "width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; "
+                    "background: radial-gradient(circle, var(--q-primary, #1976d2) 35%, white 35%);"
+                )
+            else:
+                # Default state - empty ring
+                chip.classes(
+                    remove="bg-primary text-white",
+                    add="bg-gray-100 text-gray-700 hover:bg-gray-200",
+                )
+                dot.style(
+                    "width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; "
+                    "background: transparent; border: 2px solid #9ca3af;"
+                )
+
+    def select_location(location_id: int) -> None:
+        """Handle chip selection."""
+        if current_value[0] != location_id:
+            current_value[0] = location_id
+            update_chip_styles()
+            if on_change:
+                on_change(location_id)
+
+    # Container with flex-wrap for responsive layout
+    with ui.row().classes("flex-wrap gap-2") as container:
+        for location in locations:
+            # Skip locations without ID (shouldn't happen in practice)
+            if location.id is None:
+                continue
+            loc_id: int = location.id
+            is_selected = loc_id == value
+
+            # Create chip as button for proper click handling
+            chip = (
+                ui.button(
+                    on_click=lambda _, lid=loc_id: select_location(lid),
+                )
+                .classes(
+                    "rounded-lg cursor-pointer "
+                    "transition-all duration-150 ease-in-out select-none normal-case "
+                    + ("bg-primary text-white" if is_selected else "bg-gray-100 text-gray-700 hover:bg-gray-200")
+                )
+                .style("min-height: 48px; padding: 0.5rem 0.75rem;")
+                .props("flat no-caps")
+            )
+
+            chip_refs[loc_id] = chip
+
+            # Add content to button with explicit flex container
+            with chip:
+                with ui.row().classes("items-center gap-2").style("flex-wrap: nowrap;"):
+                    # Ring-dot indicator
+                    dot = ui.element("div").style(
+                        "width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; "
+                        + (
+                            "background: radial-gradient(circle, var(--q-primary, #1976d2) 35%, white 35%);"
+                            if is_selected
+                            else "background-color: transparent; border: 2px solid #9ca3af;"
+                        )
+                    )
+                    dot_refs[loc_id] = dot
+
+                    # Label
+                    ui.label(location.name).classes("text-sm font-medium whitespace-nowrap")
+
+    return container

--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -9,6 +9,7 @@ from ...services import location_service
 from ..components import create_bottom_nav
 from ..components import create_category_chip_group
 from ..components import create_item_type_chip_group
+from ..components import create_location_chip_group
 from ..components import create_mobile_page_container
 from ..components import create_unit_chip_group
 from ..smart_defaults import create_smart_defaults_dict
@@ -408,17 +409,15 @@ def add_item() -> None:
                     warning_msg = "Kein passender Lagerort (Keller/Kühlschrank) vorhanden."
                 ui.label(warning_msg).classes("text-sm text-red-600 mb-2")
 
-            location_options = {loc.id: loc.name for loc in locations}
-            location_select = (
-                ui.select(
-                    options=location_options,
-                    value=form_data.get("location_id"),
-                )
-                .classes("w-full")
-                .props("outlined")
+            def on_location_change(location_id: int) -> None:
+                form_data["location_id"] = location_id
+                update_step3_validation()
+
+            create_location_chip_group(
+                locations=locations,
+                value=form_data.get("location_id"),
+                on_change=on_location_change,
             )
-            location_select.bind_value(form_data, "location_id")
-            location_select.on("update:model-value", update_step3_validation)
 
             # Notes (optional)
             ui.label("Notizen (optional)").classes("text-sm font-medium mb-1 mt-4")

--- a/tests/test_ui/test_location_chips.py
+++ b/tests/test_ui/test_location_chips.py
@@ -1,0 +1,51 @@
+"""UI Tests for Location Chip Group component."""
+
+from app.models.location import Location
+from app.models.location import LocationType
+from nicegui.testing import User
+from sqlmodel import Session
+
+
+async def test_location_chips_page_loads(user: User) -> None:
+    """Test that location chips page loads without error."""
+    await user.open("/test/location-chips")
+
+    # Verify page loads
+    await user.should_see("Location Chips Test")
+
+
+async def test_location_chips_displays_locations(user: User, isolated_test_database) -> None:
+    """Test that location chips are displayed when locations exist."""
+    # Create test location in database
+    with Session(isolated_test_database) as session:
+        location = Location(
+            name="Tiefkühltruhe",
+            location_type=LocationType.FROZEN,
+            created_by=1,
+        )
+        session.add(location)
+        session.commit()
+
+    await user.open("/test/location-chips")
+
+    # Verify page loads
+    await user.should_see("Location Chips Test")
+
+    # Verify location is visible
+    await user.should_see("Tiefkühltruhe")
+
+
+async def test_location_chips_preselected_value(user: User) -> None:
+    """Test that preselected value page loads correctly."""
+    await user.open("/test/location-chips-preselected")
+
+    # Verify the page loads
+    await user.should_see("Location Chips Test (Preselected)")
+
+
+async def test_location_chips_shows_selection(user: User) -> None:
+    """Test that initially no selection is shown."""
+    await user.open("/test/location-chips")
+
+    # Initially no selection
+    await user.should_see("Selected: None")


### PR DESCRIPTION
## Summary

- Neue `create_location_chip_group` Komponente für touch-freundliche Lagerort-Auswahl
- Ersetzt Dropdown im Wizard Schritt 3 durch Chip-Reihe
- Tests für die neue Komponente

## Änderungen

- `app/ui/components/location_chips.py` - Neue Chip-Komponente
- `app/ui/pages/add_item.py` - Wizard verwendet jetzt Chips statt Dropdown
- `app/ui/test_pages/test_chips.py` - Test-Seiten für Location-Chips
- `tests/test_ui/test_location_chips.py` - UI-Tests

## Test plan

- [x] UI-Tests für Location-Chips bestehen
- [x] Alle bestehenden Tests bestehen (409 passed)
- [x] mypy: keine Fehler
- [x] ruff: keine Fehler

closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)