### PR TITLE
feat: Kategorien sortierbar mit Up/Down Buttons

### DIFF
--- a/alembic/versions/86ddeb1af50f_add_sort_order_to_category.py
+++ b/alembic/versions/86ddeb1af50f_add_sort_order_to_category.py
@@ -1,0 +1,32 @@
+"""add sort_order to category
+
+Revision ID: 86ddeb1af50f
+Revises: 094bc98ee7ff
+Create Date: 2025-11-30 19:23:09.369029
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '86ddeb1af50f'
+down_revision: Union[str, Sequence[str], None] = '094bc98ee7ff'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add sort_order column with server default for existing rows
+    op.add_column(
+        'category',
+        sa.Column('sort_order', sa.Integer(), nullable=False, server_default='0')
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('category', 'sort_order')

--- a/app/models/category.py
+++ b/app/models/category.py
@@ -18,5 +18,6 @@ class Category(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(index=True, unique=True)
     color: str | None = Field(default=None)  # Hex color code (e.g., "#FF5733")
+    sort_order: int = Field(default=0)  # For drag & drop sorting
     created_at: datetime = Field(default_factory=datetime.now)
     created_by: int = Field(foreign_key="users.id")


### PR DESCRIPTION
## Summary

- Neues `sort_order` Feld im Category Model
- Alembic Migration für das neue Feld (mit server_default='0' für bestehende Einträge)
- `get_all_categories()` gibt Kategorien nach sort_order sortiert zurück
- Neue Kategorien erhalten automatisch die nächste Position (max + 1)
- Up/Down Buttons in der Kategorien-Verwaltung (Mobile-freundlich statt Drag & Drop)
- Service-Methode `update_category_order()` für Reihenfolge-Updates
- 4 neue Tests für Sortierungsfunktionalität

## Test plan

- [x] `uv run pytest` - alle 422 Tests bestehen
- [x] `uv run mypy app/` - keine Typ-Fehler
- [x] `uv run ruff check app/` - keine Linting-Fehler
- [ ] Manueller Test: Kategorien in Settings sortieren

closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)