### PR TITLE
feat: Phase 4: Solarpunk Pages

### DIFF
--- a/app/ui/auth.py
+++ b/app/ui/auth.py
@@ -98,17 +98,17 @@ def show_login_page() -> None:
                 else:
                     ui.notify(str(e), type="negative")
 
-    # Mobile-First Layout: Full-screen auf Mobile, zentrierte Card auf Desktop
-    with ui.column().classes("w-full min-h-screen items-center justify-center bg-gray-100 p-4"):
+    # Mobile-First Layout: Full-screen auf Mobile, zentrierte Card auf Desktop (Solarpunk theme)
+    with ui.column().classes("w-full min-h-screen items-center justify-center bg-cream p-4"):
         # Responsive Card: full width auf Mobile, max-w-md auf Desktop
-        with ui.card().classes("w-full max-w-md"):
+        with ui.card().classes("sp-dashboard-card w-full max-w-md p-6"):
             # Logo Placeholder (wird spaeter durch echtes Logo ersetzt)
             with ui.row().classes("w-full justify-center mb-4"):
-                ui.icon("kitchen", size="64px").classes("text-primary")
+                ui.icon("kitchen", size="64px").classes("text-fern")
 
-            # Titel
-            ui.label("Füllhorn").classes("text-h4 text-center w-full mb-2")
-            ui.label("Lebensmittelvorrats-Verwaltung").classes("text-subtitle2 text-center w-full mb-6 text-gray-600")
+            # Titel (Solarpunk display font)
+            ui.label("Füllhorn").classes("font-display text-h4 text-fern text-center w-full mb-2")
+            ui.label("Lebensmittelvorrats-Verwaltung").classes("text-subtitle2 text-center w-full mb-6 text-stone")
 
             # Formular
             with ui.column().classes("w-full gap-4"):
@@ -131,9 +131,9 @@ def show_login_page() -> None:
                 # Enter-Taste fuer Submit
                 password_input.on("keydown.enter", handle_login)
 
-                # Login Button - groesser fuer Touch (min 48px)
-                ui.button("Anmelden", on_click=handle_login).props("color=primary size=lg").classes(
-                    "w-full mt-4"
+                # Login Button - groesser fuer Touch (min 48px), Solarpunk primary button
+                ui.button("Anmelden", on_click=handle_login).classes("w-full mt-4 sp-btn-primary").props(
+                    "size=lg"
                 ).style("min-height: 48px")
 
 

--- a/app/ui/pages/add_item.py
+++ b/app/ui/pages/add_item.py
@@ -112,11 +112,11 @@ def add_item() -> None:
         # Clear and rebuild UI for Step 1 (like show_step2 and show_step3)
         content_container.clear()
         with content_container:
-            # Progress Indicator
-            ui.label("Schritt 1 von 3").classes("text-sm text-gray-600 mb-4")
+            # Progress Indicator (Solarpunk theme)
+            ui.label("Schritt 1 von 3").classes("text-sm text-stone mb-4")
 
             # Step 1: Basic Information
-            ui.label("Basisinformationen").classes("text-h6 font-semibold mb-3")
+            ui.label("Basisinformationen").classes("sp-page-title text-base mb-3")
 
             # Product Name
             ui.label("Produktname *").classes("text-sm font-medium mb-1")
@@ -200,13 +200,13 @@ def add_item() -> None:
         # Clear and rebuild UI for Step 2
         content_container.clear()
         with content_container:
-            # Progress Indicator
-            ui.label("Schritt 2 von 3").classes("text-sm text-gray-600 mb-4")
+            # Progress Indicator (Solarpunk theme)
+            ui.label("Schritt 2 von 3").classes("text-sm text-stone mb-4")
 
             # Step 2: Shelf Life Information
-            ui.label("Haltbarkeit").classes("text-h6 font-semibold mb-3")
+            ui.label("Haltbarkeit").classes("sp-page-title text-base mb-3")
 
-            # Summary from Step 1
+            # Summary from Step 1 (Solarpunk summary box)
             item_type_labels = {
                 ItemType.PURCHASED_FRESH: "Frisch eingekauft",
                 ItemType.PURCHASED_FROZEN: "TK-Ware gekauft",
@@ -216,11 +216,11 @@ def add_item() -> None:
             }
             type_label = item_type_labels.get(item_type, "")
 
-            with ui.card().classes("w-full bg-gray-50 p-3 mb-4"):
-                ui.label("Zusammenfassung:").classes("text-sm font-medium mb-2")
+            with ui.element("div").classes("sp-summary-box w-full mb-4"):
+                ui.label("Zusammenfassung:").classes("sp-summary-title")
                 ui.label(
                     f"{form_data['product_name']} • {form_data['quantity']} {form_data['unit']} • {type_label}"
-                ).classes("text-sm")
+                ).classes("sp-summary-content")
 
             # Category Chips (only for types that need shelf life from DB)
             if needs_category:
@@ -228,7 +228,7 @@ def add_item() -> None:
                     categories = category_service.get_all_categories(session)
 
                 ui.label("Kategorie *").classes("text-sm font-medium mb-2")
-                ui.label("Bestimmt die Haltbarkeit").classes("text-xs text-gray-600 mb-2")
+                ui.label("Bestimmt die Haltbarkeit").classes("text-xs text-stone mb-2")
 
                 def on_category_change(category_id: int) -> None:
                     form_data["category_id"] = category_id
@@ -347,13 +347,13 @@ def add_item() -> None:
         # Clear and rebuild UI for Step 3
         content_container.clear()
         with content_container:
-            # Progress Indicator
-            ui.label("Schritt 3 von 3").classes("text-sm text-gray-600 mb-4")
+            # Progress Indicator (Solarpunk theme)
+            ui.label("Schritt 3 von 3").classes("text-sm text-stone mb-4")
 
             # Step 3: Location & Notes
-            ui.label("Lagerort & Notizen").classes("text-h6 font-semibold mb-3")
+            ui.label("Lagerort & Notizen").classes("sp-page-title text-base mb-3")
 
-            # Summary from Steps 1-2
+            # Summary from Steps 1-2 (Solarpunk summary box)
             item_type_labels = {
                 ItemType.PURCHASED_FRESH: "Frisch eingekauft",
                 ItemType.PURCHASED_FROZEN: "TK-Ware gekauft",
@@ -371,8 +371,8 @@ def add_item() -> None:
                     if category:
                         category_name = category.name
 
-            with ui.card().classes("w-full bg-gray-50 p-3 mb-4"):
-                ui.label("Zusammenfassung:").classes("text-sm font-medium mb-2")
+            with ui.element("div").classes("sp-summary-box w-full mb-4"):
+                ui.label("Zusammenfassung:").classes("sp-summary-title")
                 summary_parts = [
                     form_data["product_name"],
                     f"{form_data['quantity']} {form_data['unit']}",
@@ -380,7 +380,7 @@ def add_item() -> None:
                 ]
                 if category_name:
                     summary_parts.append(category_name)
-                ui.label(" • ".join(summary_parts)).classes("text-sm")
+                ui.label(" • ".join(summary_parts)).classes("sp-summary-content")
 
                 # Date info
                 best_before_str = form_data["best_before_date"].strftime("%d.%m.%Y")
@@ -388,7 +388,7 @@ def add_item() -> None:
                 if form_data.get("freeze_date"):
                     freeze_str = form_data["freeze_date"].strftime("%d.%m.%Y")
                     date_info += f" • Eingefroren: {freeze_str}"
-                ui.label(date_info).classes("text-sm")
+                ui.label(date_info).classes("sp-summary-content")
 
             # Fetch locations filtered by item type
             with next(get_session()) as session:
@@ -407,7 +407,7 @@ def add_item() -> None:
                     warning_msg = "Kein Tiefkühl-Lagerort vorhanden. Bitte zuerst einen anlegen."
                 else:
                     warning_msg = "Kein passender Lagerort (Keller/Kühlschrank) vorhanden."
-                ui.label(warning_msg).classes("text-sm text-red-600 mb-2")
+                ui.label(warning_msg).classes("text-sm sp-expiry-critical mb-2")
 
             def on_location_change(location_id: int) -> None:
                 form_data["location_id"] = location_id
@@ -540,19 +540,21 @@ def add_item() -> None:
         # Reset wizard with smart defaults and reload page
         ui.navigate.to("/items/add")
 
-    # Header with title and close button
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
-        ui.label("Artikel erfassen").classes("text-h5 font-bold text-primary")
-        ui.button(icon="close", on_click=lambda: ui.navigate.to("/dashboard")).props("flat round color=gray-7")
+    # Header with title and close button (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
+        ui.label("Artikel erfassen").classes("sp-page-title")
+        ui.button(icon="close", on_click=lambda: ui.navigate.to("/dashboard")).classes("sp-back-btn").props(
+            "flat round"
+        )
 
     # Main content container (max-width handled by create_mobile_page_container)
     content_container = create_mobile_page_container()
     with content_container:
-        # Progress Indicator
-        ui.label("Schritt 1 von 3").classes("text-sm text-gray-600 mb-4")
+        # Progress Indicator (Solarpunk theme)
+        ui.label("Schritt 1 von 3").classes("text-sm text-stone mb-4")
 
         # Step 1: Basic Information
-        ui.label("Basisinformationen").classes("text-h6 font-semibold mb-3")
+        ui.label("Basisinformationen").classes("sp-page-title text-base mb-3")
 
         # Product Name
         ui.label("Produktname *").classes("text-sm font-medium mb-1")

--- a/app/ui/pages/dashboard.py
+++ b/app/ui/pages/dashboard.py
@@ -22,15 +22,15 @@ from nicegui import ui
 def dashboard() -> None:
     """Dashboard mit Ablaufübersicht und Statistiken (Mobile-First)."""
 
-    # Header with user dropdown
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
-        ui.label("Füllhorn").classes("text-h5 font-bold text-primary")
+    # Header with user dropdown (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
+        ui.label("Füllhorn").classes("sp-page-title")
         create_user_dropdown()
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
         # Expiring items section
-        ui.label("🔴 Bald abgelaufen").classes("text-h6 font-semibold mb-3")
+        ui.label("Bald abgelaufen").classes("sp-page-title text-base mb-3")
 
         with next(get_session()) as session:
             # Get items expiring in next 7 days
@@ -45,31 +45,31 @@ def dashboard() -> None:
                         on_consume=lambda i=item: handle_consume(i),  # type: ignore[misc]
                     )
             else:
-                ui.label("✅ Keine Artikel laufen in den nächsten 7 Tagen ab!").classes(
-                    "text-green-600 p-4 bg-green-50 rounded"
+                ui.label("Keine Artikel laufen in den nächsten 7 Tagen ab!").classes(
+                    "sp-expiry-ok p-4 bg-oat rounded-sp-md"
                 )
 
             # Statistics section
-            ui.label("📊 Vorrats-Statistik").classes("text-h6 font-semibold mb-3 mt-6")
+            ui.label("Vorrats-Statistik").classes("sp-page-title text-base mb-3 mt-6")
 
             all_items = item_service.get_all_items(session)
             consumed_items = [i for i in all_items if i.is_consumed]
             active_items = [i for i in all_items if not i.is_consumed]
 
-            with ui.card().classes("w-full"):
-                with ui.row().classes("w-full justify-around text-center"):
+            with ui.card().classes("sp-dashboard-card w-full"):
+                with ui.row().classes("sp-stats-row w-full"):
                     with ui.column():
-                        ui.label(str(len(active_items))).classes("text-2xl font-bold text-primary")
-                        ui.label("Artikel").classes("text-sm text-gray-600")
+                        ui.label(str(len(active_items))).classes("sp-stats-number primary")
+                        ui.label("Artikel").classes("sp-stats-label")
                     with ui.column():
-                        ui.label(str(len(expiring_items))).classes("text-2xl font-bold text-orange-500")
-                        ui.label("Ablauf").classes("text-sm text-gray-600")
+                        ui.label(str(len(expiring_items))).classes("sp-stats-number warning")
+                        ui.label("Ablauf").classes("sp-stats-label")
                     with ui.column():
-                        ui.label(str(len(consumed_items))).classes("text-2xl font-bold text-green-500")
-                        ui.label("Entn.").classes("text-sm text-gray-600")
+                        ui.label(str(len(consumed_items))).classes("sp-stats-number success")
+                        ui.label("Entn.").classes("sp-stats-label")
 
             # Quick filters section
-            ui.label("🏷️ Schnellfilter").classes("text-h6 font-semibold mb-3 mt-6")
+            ui.label("Schnellfilter").classes("sp-page-title text-base mb-3 mt-6")
 
             # Get unique locations with names
             location_items: dict[int, str] = {}
@@ -86,7 +86,7 @@ def dashboard() -> None:
                     ui.button(
                         loc_name,
                         on_click=lambda loc=loc_id: ui.navigate.to(f"/items?location={loc}"),
-                    ).props("outline color=primary size=sm")
+                    ).classes("sp-quick-filter").props("flat no-caps")
 
     # Bottom Navigation (always visible)
     create_bottom_nav(current_page="dashboard")

--- a/app/ui/pages/items.py
+++ b/app/ui/pages/items.py
@@ -50,22 +50,22 @@ ITEM_TYPE_LABELS: dict[str, str] = {
 
 def _render_empty_state() -> None:
     """Render empty state when no items exist or no search results."""
-    with ui.card().classes("w-full p-6 text-center"):
-        ui.icon("inventory_2").classes("text-6xl text-gray-300 mb-4")
-        ui.label("Keine Artikel vorhanden").classes("text-lg text-gray-600 mb-2")
-        ui.label("Erfasse deinen ersten Artikel!").classes("text-sm text-gray-500")
+    with ui.card().classes("sp-dashboard-card w-full p-6 text-center"):
+        ui.icon("inventory_2").classes("text-6xl text-stone mb-4")
+        ui.label("Keine Artikel vorhanden").classes("text-lg text-charcoal mb-2")
+        ui.label("Erfasse deinen ersten Artikel!").classes("text-sm text-stone")
         ui.button(
             "Artikel erfassen",
             on_click=lambda: ui.navigate.to("/add-item"),
-        ).classes("mt-4")
+        ).classes("mt-4 sp-btn-primary")
 
 
 def _render_no_filter_results() -> None:
     """Render message when filters yield no results."""
-    with ui.card().classes("w-full p-6 text-center"):
-        ui.icon("search_off").classes("text-6xl text-gray-300 mb-4")
-        ui.label("Keine Artikel gefunden").classes("text-lg text-gray-600 mb-2")
-        ui.label("Versuche andere Filter oder Suchbegriffe").classes("text-sm text-gray-500")
+    with ui.card().classes("sp-dashboard-card w-full p-6 text-center"):
+        ui.icon("search_off").classes("text-6xl text-stone mb-4")
+        ui.label("Keine Artikel gefunden").classes("text-lg text-charcoal mb-2")
+        ui.label("Versuche andere Filter oder Suchbegriffe").classes("text-sm text-stone")
 
 
 def _build_item_category_map(items: list[Item]) -> dict[int, int | None]:
@@ -309,9 +309,9 @@ def items_page() -> None:
             )
             sheet.open()
 
-    # Header with toggle
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
-        ui.label("Vorrat").classes("text-h5 font-bold text-primary")
+    # Header with toggle (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
+        ui.label("Vorrat").classes("sp-page-title")
         # Toggle for showing consumed items
         ui.switch("Entnommene anzeigen", value=show_consumed, on_change=on_toggle_change).classes("text-sm")
 


### PR DESCRIPTION
## Summary
- Apply Solarpunk theme CSS classes to all main user-facing pages
- Dashboard: `sp-page-header`, `sp-dashboard-card`, `sp-stats-row`, `sp-quick-filter` classes
- Items/Vorrat page: Themed header and empty states
- Add Item Wizard: `sp-summary-box` for summaries, themed progress indicators
- Login page: Cream background, display font title, themed card and button

## Test plan
- [x] All 453 tests pass
- [x] mypy type check passes
- [x] ruff lint/format passes
- [ ] Manual testing: verify cream background on all pages
- [ ] Manual testing: verify headers styled uniformly
- [ ] Manual testing: verify forms use themed inputs

closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)