### PR TITLE
feat: Phase 5: Solarpunk Admin Pages

### DIFF
--- a/app/ui/pages/categories.py
+++ b/app/ui/pages/categories.py
@@ -31,20 +31,22 @@ STORAGE_TYPE_LABELS = {
 def categories_page() -> None:
     """Categories management page (Mobile-First)."""
 
-    # Header
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+    # Header (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
         with ui.row().classes("items-center gap-2"):
-            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).props(
-                "flat round color=gray-7"
-            )
-            ui.label("Kategorien").classes("text-h5 font-bold text-primary")
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).classes(
+                "sp-back-btn"
+            ).props("flat round")
+            ui.label("Kategorien").classes("sp-page-title")
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
-        # Section header with "Neue Kategorie" button
+        # Section header with "Neue Kategorie" button (Solarpunk theme)
         with ui.row().classes("w-full items-center justify-between mb-3"):
-            ui.label("Kategorien verwalten").classes("text-h6 font-semibold")
-            ui.button("Neue Kategorie", icon="add", on_click=_open_create_dialog).props("color=primary size=sm")
+            ui.label("Kategorien verwalten").classes("text-h6 font-semibold text-fern")
+            ui.button("Neue Kategorie", icon="add", on_click=_open_create_dialog).classes("sp-btn-primary").props(
+                "size=sm"
+            )
 
         _render_categories_list()
 
@@ -125,68 +127,68 @@ def _render_categories_list() -> None:
                 is_first = index == 0
                 is_last = index == len(categories) - 1
 
-                with ui.card().classes("w-full mb-2"):
-                    with ui.row().classes("w-full items-center justify-between"):
-                        # Left side: reorder buttons + color + name
-                        with ui.row().classes("items-center gap-2"):
-                            # Reorder buttons (up/down)
-                            with ui.column().classes("gap-0"):
-                                ui.button(
-                                    icon="keyboard_arrow_up",
-                                    on_click=lambda cid=cat_id: _move_category_up(cid),
-                                ).props(f"flat round dense size=xs {'disabled' if is_first else ''}").classes(
-                                    "h-5"
-                                ).mark(f"move-up-{category.name}")
-                                ui.button(
-                                    icon="keyboard_arrow_down",
-                                    on_click=lambda cid=cat_id: _move_category_down(cid),
-                                ).props(f"flat round dense size=xs {'disabled' if is_last else ''}").classes(
-                                    "h-5"
-                                ).mark(f"move-down-{category.name}")
+                # Admin list item (Solarpunk theme)
+                with ui.element("div").classes("sp-admin-list-item w-full"):
+                    # Left side: reorder buttons + color + name
+                    with ui.row().classes("items-center gap-3 flex-1"):
+                        # Reorder buttons (drag handle style)
+                        with ui.column().classes("gap-0 sp-admin-drag"):
+                            ui.button(
+                                icon="keyboard_arrow_up",
+                                on_click=lambda cid=cat_id: _move_category_up(cid),
+                            ).props(f"flat round dense size=xs {'disabled' if is_first else ''}").classes("h-5").mark(
+                                f"move-up-{category.name}"
+                            )
+                            ui.button(
+                                icon="keyboard_arrow_down",
+                                on_click=lambda cid=cat_id: _move_category_down(cid),
+                            ).props(f"flat round dense size=xs {'disabled' if is_last else ''}").classes("h-5").mark(
+                                f"move-down-{category.name}"
+                            )
 
-                            # Color indicator
-                            if category.color:
-                                ui.element("div").classes("w-6 h-6 rounded-full").style(
-                                    f"background-color: {category.color}"
-                                )
-                            else:
-                                ui.element("div").classes("w-6 h-6 rounded-full bg-gray-300")
-                            # Category name
-                            ui.label(category.name).classes("font-medium text-lg")
+                        # Color indicator (Solarpunk admin color dot)
+                        if category.color:
+                            ui.element("div").classes("sp-admin-color-dot").style(f"background-color: {category.color}")
+                        else:
+                            ui.element("div").classes("sp-admin-color-dot bg-oat")
+                        # Category name
+                        ui.label(category.name).classes("font-medium text-lg text-charcoal")
 
-                        # Right side: shelf life info and buttons
-                        with ui.row().classes("items-center gap-2"):
-                            # Shelf life info (compact display)
-                            _render_shelf_life_badges(shelf_life_dict)
+                    # Right side: shelf life info and buttons
+                    with ui.row().classes("items-center gap-2"):
+                        # Shelf life info (compact display)
+                        _render_shelf_life_badges(shelf_life_dict)
 
-                            # Capture category data for the closures
-                            cat_name = category.name
-                            cat_color = category.color
+                        # Capture category data for the closures
+                        cat_name = category.name
+                        cat_color = category.color
 
+                        # Action buttons (Solarpunk theme)
+                        with ui.row().classes("sp-admin-actions items-center gap-1"):
                             # Edit button
                             ui.button(
                                 icon="edit",
                                 on_click=lambda cid=cat_id, cn=cat_name, cc=cat_color: _open_edit_dialog(cid, cn, cc),
-                            ).props("flat round color=grey-7 size=sm").mark(f"edit-{cat_name}")
+                            ).props("flat round size=sm").classes("edit").mark(f"edit-{cat_name}")
 
                             # Delete button
                             ui.button(
                                 icon="delete",
                                 on_click=lambda cid=cat_id, cn=cat_name: _open_delete_dialog(cid, cn),
-                            ).props("flat round color=red-7 size=sm").mark(f"delete-{cat_name}")
+                            ).props("flat round size=sm").classes("delete").mark(f"delete-{cat_name}")
         else:
-            # Empty state
-            with ui.card().classes("w-full"):
+            # Empty state (Solarpunk theme)
+            with ui.card().classes("sp-dashboard-card w-full"):
                 with ui.column().classes("w-full items-center py-8"):
-                    ui.icon("category", size="48px").classes("text-gray-400 mb-2")
-                    ui.label("Keine Kategorien vorhanden").classes("text-gray-600 text-center")
+                    ui.icon("category", size="48px").classes("text-stone mb-2")
+                    ui.label("Keine Kategorien vorhanden").classes("text-charcoal text-center")
                     ui.label("Kategorien helfen beim Organisieren des Vorrats.").classes(
-                        "text-sm text-gray-500 text-center"
+                        "text-sm text-stone text-center"
                     )
 
 
 def _render_shelf_life_badges(shelf_life_dict: dict) -> None:
-    """Render compact shelf life badges."""
+    """Render compact shelf life badges (Solarpunk theme)."""
     for storage_type in [StorageType.FROZEN, StorageType.CHILLED, StorageType.AMBIENT]:
         if storage_type in shelf_life_dict:
             sl = shelf_life_dict[storage_type]
@@ -197,14 +199,14 @@ def _render_shelf_life_badges(shelf_life_dict: dict) -> None:
                 else ("kitchen" if storage_type == StorageType.CHILLED else "home")
             )
             with ui.row().classes("items-center gap-1"):
-                ui.icon(icon, size="16px").classes("text-gray-500")
-                ui.label(f"{sl.months_min}-{sl.months_max}").classes("text-xs text-gray-600")
+                ui.icon(icon, size="16px").classes("text-stone")
+                ui.label(f"{sl.months_min}-{sl.months_max}").classes("text-xs text-stone")
 
 
 def _open_create_dialog() -> None:
     """Open dialog to create a new category."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-lg"):
-        ui.label("Neue Kategorie erstellen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-lg"):
+        ui.label("Neue Kategorie erstellen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Name input (required)
         name_input = ui.input(label="Name", placeholder="z.B. Gemüse").classes("w-full mb-2").props("outlined")
@@ -278,9 +280,9 @@ def _open_create_dialog() -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_category() -> None:
                 """Validate and save the new category."""
@@ -360,7 +362,7 @@ def _open_create_dialog() -> None:
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_category).props("color=primary")
+            ui.button("Speichern", on_click=save_category).classes("sp-btn-primary")
 
     dialog.open()
 
@@ -376,8 +378,8 @@ def _open_edit_dialog(
         shelf_lives = shelf_life_service.get_all_shelf_lives_for_category(session, category_id)
         existing_shelf_lives = {sl.storage_type: sl for sl in shelf_lives}
 
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-lg"):
-        ui.label("Kategorie bearbeiten").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-lg"):
+        ui.label("Kategorie bearbeiten").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Name input (pre-filled)
         name_input = (
@@ -455,9 +457,9 @@ def _open_edit_dialog(
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_changes() -> None:
                 """Validate and save the category changes."""
@@ -536,15 +538,15 @@ def _open_edit_dialog(
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_changes).props("color=primary")
+            ui.button("Speichern", on_click=save_changes).classes("sp-btn-primary")
 
     dialog.open()
 
 
 def _open_delete_dialog(category_id: int, category_name: str) -> None:
     """Open confirmation dialog to delete a category."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Kategorie löschen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Kategorie löschen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Warning message
         ui.label(f"Möchten Sie die Kategorie '{category_name}' wirklich löschen?").classes("mb-2")
@@ -554,9 +556,9 @@ def _open_delete_dialog(category_id: int, category_name: str) -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def confirm_delete() -> None:
                 """Perform the deletion."""
@@ -577,6 +579,6 @@ def _open_delete_dialog(category_id: int, category_name: str) -> None:
                     error_label.set_text(str(e))
                     error_label.set_visibility(True)
 
-            ui.button("Löschen", on_click=confirm_delete).props("color=red")
+            ui.button("Löschen", on_click=confirm_delete).classes("sp-btn-danger")
 
     dialog.open()

--- a/app/ui/pages/locations.py
+++ b/app/ui/pages/locations.py
@@ -53,74 +53,76 @@ def _get_location_type_icon(location_type: LocationType) -> str:
 def locations_page() -> None:
     """Locations management page (Mobile-First)."""
 
-    # Header
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+    # Header (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
         with ui.row().classes("items-center gap-2"):
-            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).props(
-                "flat round color=gray-7"
-            )
-            ui.label("Lagerorte").classes("text-h5 font-bold text-primary")
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).classes(
+                "sp-back-btn"
+            ).props("flat round")
+            ui.label("Lagerorte").classes("sp-page-title")
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
-        # Section header with "Neuer Lagerort" button
+        # Section header with "Neuer Lagerort" button (Solarpunk theme)
         with ui.row().classes("w-full items-center justify-between mb-3"):
-            ui.label("Lagerorte verwalten").classes("text-h6 font-semibold")
-            ui.button("Neuer Lagerort", icon="add", on_click=_open_create_dialog).props("color=primary size=sm")
+            ui.label("Lagerorte verwalten").classes("text-h6 font-semibold text-fern")
+            ui.button("Neuer Lagerort", icon="add", on_click=_open_create_dialog).classes("sp-btn-primary").props(
+                "size=sm"
+            )
 
         with next(get_session()) as session:
             locations = location_service.get_all_locations(session)
 
             if locations:
-                # Display locations as cards
+                # Display locations as admin list items (Solarpunk theme)
                 for location in locations:
-                    with ui.card().classes("w-full mb-2"):
-                        with ui.row().classes("w-full items-center justify-between"):
-                            with ui.row().classes("items-center gap-3"):
-                                # Color indicator (or fallback to type icon)
-                                if location.color:
-                                    ui.element("div").classes("w-6 h-6 rounded-full").style(
-                                        f"background-color: {location.color}"
-                                    )
-                                else:
-                                    ui.icon(
-                                        _get_location_type_icon(location.location_type),
-                                        size="24px",
-                                    ).classes(f"text-{_get_location_type_color(location.location_type)}")
-                                # Location name
-                                ui.label(location.name).classes("font-medium text-lg")
-                            # Type badge, status, edit and delete buttons
-                            with ui.row().classes("items-center gap-2"):
-                                # Type badge
-                                ui.badge(
-                                    _get_location_type_label(location.location_type),
-                                    color=_get_location_type_color(location.location_type),
-                                ).classes("text-xs")
-                                # Inactive badge (if not active)
-                                if not location.is_active:
-                                    ui.badge("Inaktiv", color="red").classes("text-xs")
+                    with ui.element("div").classes("sp-admin-list-item w-full"):
+                        # Left side: color + name
+                        with ui.row().classes("items-center gap-3 flex-1"):
+                            # Color indicator (Solarpunk admin color dot)
+                            if location.color:
+                                ui.element("div").classes("sp-admin-color-dot").style(
+                                    f"background-color: {location.color}"
+                                )
+                            else:
+                                ui.icon(
+                                    _get_location_type_icon(location.location_type),
+                                    size="24px",
+                                ).classes(f"text-{_get_location_type_color(location.location_type)}")
+                            # Location name
+                            ui.label(location.name).classes("font-medium text-lg text-charcoal")
+                        # Right side: Type badge, status, edit and delete buttons
+                        with ui.row().classes("items-center gap-2"):
+                            # Type badge
+                            ui.badge(
+                                _get_location_type_label(location.location_type),
+                                color=_get_location_type_color(location.location_type),
+                            ).classes("text-xs")
+                            # Inactive badge (if not active)
+                            if not location.is_active:
+                                ui.badge("Inaktiv", color="red").classes("text-xs")
+                            # Action buttons (Solarpunk theme)
+                            with ui.row().classes("sp-admin-actions items-center gap-1"):
                                 # Edit button
                                 ui.button(
                                     icon="edit",
                                     on_click=lambda loc=location: _open_edit_dialog(loc),
-                                ).props("flat round size=sm").classes("min-w-0")
+                                ).props("flat round size=sm").classes("edit min-w-0")
                                 # Delete button
                                 location_id = location.id
                                 location_name = location.name
                                 ui.button(
                                     icon="delete",
                                     on_click=lambda lid=location_id, ln=location_name: _open_delete_dialog(lid, ln),
-                                ).props("flat round color=red-7 size=sm").classes("min-w-0").mark(
-                                    f"delete-{location_name}"
-                                )
+                                ).props("flat round size=sm").classes("delete min-w-0").mark(f"delete-{location_name}")
             else:
-                # Empty state
-                with ui.card().classes("w-full"):
+                # Empty state (Solarpunk theme)
+                with ui.card().classes("sp-dashboard-card w-full"):
                     with ui.column().classes("w-full items-center py-8"):
-                        ui.icon("place", size="48px").classes("text-gray-400 mb-2")
-                        ui.label("Keine Lagerorte vorhanden").classes("text-gray-600 text-center")
+                        ui.icon("place", size="48px").classes("text-stone mb-2")
+                        ui.label("Keine Lagerorte vorhanden").classes("text-charcoal text-center")
                         ui.label("Lagerorte helfen beim Organisieren des Vorrats.").classes(
-                            "text-sm text-gray-500 text-center"
+                            "text-sm text-stone text-center"
                         )
 
 
@@ -133,8 +135,8 @@ def _open_edit_dialog(location: Location) -> None:
         LocationType.AMBIENT: "Raumtemperatur",
     }
 
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Lagerort bearbeiten").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Lagerort bearbeiten").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Name input (required, pre-filled)
         name_input = (
@@ -196,7 +198,7 @@ def _open_edit_dialog(location: Location) -> None:
 
         # Buttons
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_location() -> None:
                 """Validate and save the location changes."""
@@ -241,7 +243,7 @@ def _open_edit_dialog(location: Location) -> None:
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_location).props("color=primary")
+            ui.button("Speichern", on_click=save_location).classes("sp-btn-primary")
 
     dialog.open()
 
@@ -255,8 +257,8 @@ def _open_create_dialog() -> None:
         LocationType.AMBIENT: "Raumtemperatur",
     }
 
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Neuen Lagerort erstellen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Neuen Lagerort erstellen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Name input (required)
         name_input = (
@@ -309,9 +311,9 @@ def _open_create_dialog() -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_location() -> None:
                 """Validate and save the new location."""
@@ -355,15 +357,15 @@ def _open_create_dialog() -> None:
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_location).props("color=primary")
+            ui.button("Speichern", on_click=save_location).classes("sp-btn-primary")
 
     dialog.open()
 
 
 def _open_delete_dialog(location_id: int, location_name: str) -> None:
     """Open confirmation dialog to delete a location."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Lagerort löschen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Lagerort löschen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Warning message
         ui.label(f"Möchten Sie den Lagerort '{location_name}' wirklich löschen?").classes("mb-2")
@@ -373,9 +375,9 @@ def _open_delete_dialog(location_id: int, location_name: str) -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def confirm_delete() -> None:
                 """Perform the deletion."""
@@ -399,6 +401,6 @@ def _open_delete_dialog(location_id: int, location_name: str) -> None:
                     error_label.set_text(str(e))
                     error_label.set_visibility(True)
 
-            ui.button("Löschen", on_click=confirm_delete).props("color=red")
+            ui.button("Löschen", on_click=confirm_delete).classes("sp-btn-danger")
 
     dialog.open()

--- a/app/ui/pages/profile.py
+++ b/app/ui/pages/profile.py
@@ -35,11 +35,13 @@ def profile() -> None:
         ui.navigate.to("/login")
         return
 
-    # Header
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+    # Header (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
         with ui.row().classes("items-center gap-2"):
-            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/dashboard")).props("flat round color=gray-7")
-            ui.label("Profil").classes("text-h5 font-bold text-primary")
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/dashboard")).classes("sp-back-btn").props(
+                "flat round"
+            )
+            ui.label("Profil").classes("sp-page-title")
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
@@ -63,10 +65,10 @@ def profile() -> None:
 
 
 def _render_account_info_section(current_user: User) -> None:
-    """Render account info section with email and username."""
-    ui.label("Konto-Informationen").classes("text-h6 font-semibold mb-3")
+    """Render account info section with email and username (Solarpunk theme)."""
+    ui.label("Konto-Informationen").classes("text-h6 font-semibold mb-3 text-fern")
 
-    with ui.card().classes("w-full p-4"):
+    with ui.card().classes("sp-dashboard-card w-full p-4"):
         # Username (readonly)
         ui.input(
             label="Benutzername",
@@ -103,14 +105,14 @@ def _render_account_info_section(current_user: User) -> None:
             except ValueError as e:
                 ui.notify(str(e), type="negative")
 
-        ui.button("E-Mail speichern", icon="save", on_click=save_email).props("color=primary")
+        ui.button("E-Mail speichern", icon="save", on_click=save_email).classes("sp-btn-primary")
 
 
 def _render_password_change_section(current_user: User) -> None:
-    """Render password change section."""
-    ui.label("Passwort ändern").classes("text-h6 font-semibold mb-3")
+    """Render password change section (Solarpunk theme)."""
+    ui.label("Passwort ändern").classes("text-h6 font-semibold mb-3 text-fern")
 
-    with ui.card().classes("w-full p-4"):
+    with ui.card().classes("sp-dashboard-card w-full p-4"):
         # Current password
         current_pw_input = (
             ui.input(
@@ -184,7 +186,7 @@ def _render_password_change_section(current_user: User) -> None:
             except ValueError as e:
                 ui.notify(str(e), type="negative")
 
-        ui.button("Passwort ändern", icon="lock", on_click=change_password).props("color=primary")
+        ui.button("Passwort ändern", icon="lock", on_click=change_password).classes("sp-btn-primary")
 
 
 def _get_user_preferences(current_user: User) -> dict[str, Any]:
@@ -202,17 +204,17 @@ def _get_user_preferences(current_user: User) -> dict[str, Any]:
 
 
 def _render_smart_defaults_section(current_user: User) -> None:
-    """Render the Smart Default settings section."""
+    """Render the Smart Default settings section (Solarpunk theme)."""
     preferences = _get_user_preferences(current_user)
 
-    ui.label("Smart Default Einstellungen").classes("text-h6 font-semibold mb-3")
+    ui.label("Smart Default Einstellungen").classes("text-h6 font-semibold mb-3 text-fern")
 
-    with ui.card().classes("w-full p-4"):
-        ui.label("Zeitfenster für automatische Vorbelegung").classes("text-body2 text-gray-600 mb-3")
+    with ui.card().classes("sp-dashboard-card w-full p-4"):
+        ui.label("Zeitfenster für automatische Vorbelegung").classes("text-body2 text-charcoal mb-3")
         ui.label(
             "Wenn Sie innerhalb des Zeitfensters einen weiteren Artikel erfassen, "
             "werden die entsprechenden Werte automatisch vorbelegt."
-        ).classes("text-caption text-gray-500 mb-4")
+        ).classes("text-caption text-stone mb-4")
 
         # Item type time window
         item_type_input = ui.number(
@@ -253,4 +255,4 @@ def _render_smart_defaults_section(current_user: User) -> None:
 
             ui.notify("Einstellungen gespeichert", type="positive")
 
-        ui.button("Speichern", icon="save", on_click=save_preferences).props("color=primary")
+        ui.button("Speichern", icon="save", on_click=save_preferences).classes("sp-btn-primary")

--- a/app/ui/pages/settings.py
+++ b/app/ui/pages/settings.py
@@ -26,11 +26,13 @@ DEFAULT_LOCATION_TIME_WINDOW = 60
 @require_permissions(Permission.CONFIG_MANAGE)
 def settings() -> None:
     """Settings page with admin navigation and system defaults (Admin only)."""
-    # Header
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+    # Header (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
         with ui.row().classes("items-center gap-2"):
-            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/dashboard")).props("flat round color=gray-7")
-            ui.label("Einstellungen").classes("text-h5 font-bold text-primary")
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/dashboard")).classes("sp-back-btn").props(
+                "flat round"
+            )
+            ui.label("Einstellungen").classes("sp-page-title")
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
@@ -48,10 +50,10 @@ def settings() -> None:
 
 
 def _render_admin_navigation() -> None:
-    """Render navigation links to admin areas."""
-    ui.label("Verwaltung").classes("text-h6 font-semibold mb-3")
+    """Render navigation links to admin areas (Solarpunk theme)."""
+    ui.label("Verwaltung").classes("text-h6 font-semibold mb-3 text-fern")
 
-    # Navigation cards
+    # Navigation cards (Solarpunk theme)
     nav_items = [
         {"icon": "category", "label": "Kategorien", "route": "/admin/categories"},
         {"icon": "place", "label": "Lagerorte", "route": "/admin/locations"},
@@ -61,14 +63,14 @@ def _render_admin_navigation() -> None:
     for item in nav_items:
         with (
             ui.card()
-            .classes("w-full mb-2 cursor-pointer hover:bg-gray-50")
+            .classes("sp-dashboard-card w-full mb-2 cursor-pointer")
             .on("click", lambda r=item["route"]: ui.navigate.to(r))
         ):
             with ui.row().classes("w-full items-center justify-between p-2"):
                 with ui.row().classes("items-center gap-3"):
-                    ui.icon(item["icon"]).classes("text-primary")
-                    ui.label(item["label"]).classes("font-medium")
-                ui.icon("chevron_right").classes("text-gray-400")
+                    ui.icon(item["icon"]).classes("text-fern")
+                    ui.label(item["label"]).classes("font-medium text-charcoal")
+                ui.icon("chevron_right").classes("text-stone")
 
 
 def _get_system_defaults() -> dict:
@@ -88,21 +90,21 @@ def _get_system_defaults() -> dict:
 
 
 def _render_system_defaults_section() -> None:
-    """Render the System Default settings section (Issue #85).
+    """Render the System Default settings section (Issue #85) (Solarpunk theme).
 
     These are fallback values for users who haven't set their own preferences.
     """
     current_user = get_current_user(require_auth=True)
     defaults = _get_system_defaults()
 
-    ui.label("System-Standardwerte").classes("text-h6 font-semibold mb-3")
+    ui.label("System-Standardwerte").classes("text-h6 font-semibold mb-3 text-fern")
 
-    with ui.card().classes("w-full p-4"):
-        ui.label("Zeitfenster für automatische Vorbelegung").classes("text-body2 text-gray-600 mb-2")
+    with ui.card().classes("sp-dashboard-card w-full p-4"):
+        ui.label("Zeitfenster für automatische Vorbelegung").classes("text-body2 text-charcoal mb-2")
         ui.label(
             "Diese Werte gelten als Fallback für Benutzer, die keine eigenen Einstellungen vorgenommen haben. "
             "Jeder Benutzer kann seine persönlichen Zeitfenster in seinem Profil anpassen."
-        ).classes("text-caption text-gray-500 mb-4")
+        ).classes("text-caption text-stone mb-4")
 
         # Item type time window
         item_type_input = ui.number(
@@ -151,4 +153,4 @@ def _render_system_defaults_section() -> None:
 
             ui.notify("System-Standardwerte gespeichert", type="positive")
 
-        ui.button("Speichern", icon="save", on_click=save_system_defaults).props("color=primary")
+        ui.button("Speichern", icon="save", on_click=save_system_defaults).classes("sp-btn-primary")

--- a/app/ui/pages/users.py
+++ b/app/ui/pages/users.py
@@ -20,26 +20,28 @@ from nicegui import ui
 @require_permissions(Permission.USER_MANAGE)
 def users_page() -> None:
     """Users management page (Mobile-First)."""
-    # Header
-    with ui.row().classes("w-full items-center justify-between p-4 bg-white border-b border-gray-200"):
+    # Header (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
         with ui.row().classes("items-center gap-2"):
-            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).props(
-                "flat round color=gray-7"
-            )
-            ui.label("Benutzer").classes("text-h5 font-bold text-primary")
+            ui.button(icon="arrow_back", on_click=lambda: ui.navigate.to("/admin/settings")).classes(
+                "sp-back-btn"
+            ).props("flat round")
+            ui.label("Benutzer").classes("sp-page-title")
 
     # Main content with bottom nav spacing
     with create_mobile_page_container():
-        # Section header with "Neuer Benutzer" button
+        # Section header with "Neuer Benutzer" button (Solarpunk theme)
         with ui.row().classes("w-full items-center justify-between mb-3"):
-            ui.label("Benutzer verwalten").classes("text-h6 font-semibold")
-            ui.button("Neuer Benutzer", icon="add", on_click=_open_create_dialog).props("color=primary size=sm")
+            ui.label("Benutzer verwalten").classes("text-h6 font-semibold text-fern")
+            ui.button("Neuer Benutzer", icon="add", on_click=_open_create_dialog).classes("sp-btn-primary").props(
+                "size=sm"
+            )
 
         _render_users_list()
 
 
 def _render_users_list() -> None:
-    """Render the list of users."""
+    """Render the list of users (Solarpunk theme)."""
     # Get current user to prevent self-deletion
     current_user = get_current_user(require_auth=True)
     current_user_id = current_user.id if current_user else None
@@ -48,34 +50,35 @@ def _render_users_list() -> None:
         users = auth_service.list_users(session)
 
         if users:
-            # Display users as cards
+            # Display users as admin list items (Solarpunk theme)
             for user in users:
-                with ui.card().classes("w-full mb-2"):
-                    with ui.row().classes("w-full items-center justify-between"):
-                        # Left side: username and role
-                        with ui.column().classes("gap-0"):
-                            ui.label(user.username).classes("font-medium text-lg")
-                            # Role badge
-                            role_display = "Admin" if user.role == "admin" else "Benutzer"
-                            role_color = "primary" if user.role == "admin" else "grey"
-                            ui.badge(role_display, color=role_color).classes("mt-1")
+                with ui.element("div").classes("sp-admin-list-item w-full"):
+                    # Left side: username and role
+                    with ui.column().classes("gap-0 flex-1"):
+                        ui.label(user.username).classes("font-medium text-lg text-charcoal")
+                        # Role badge
+                        role_display = "Admin" if user.role == "admin" else "Benutzer"
+                        role_color = "primary" if user.role == "admin" else "grey"
+                        ui.badge(role_display, color=role_color).classes("mt-1")
 
-                        # Right side: status, last login, and edit button
-                        with ui.row().classes("items-center gap-2"):
-                            with ui.column().classes("gap-0 items-end"):
-                                # Status indicator
-                                status_text = "Aktiv" if user.is_active else "Inaktiv"
-                                status_color = "text-green-600" if user.is_active else "text-red-600"
-                                ui.label(status_text).classes(f"text-sm font-medium {status_color}")
+                    # Right side: status, last login, and edit button
+                    with ui.row().classes("items-center gap-2"):
+                        with ui.column().classes("gap-0 items-end"):
+                            # Status indicator
+                            status_text = "Aktiv" if user.is_active else "Inaktiv"
+                            status_color = "text-green-600" if user.is_active else "text-red-600"
+                            ui.label(status_text).classes(f"text-sm font-medium {status_color}")
 
-                                # Last login
-                                if user.last_login:
-                                    login_date = user.last_login.strftime("%d.%m.%Y")
-                                    login_time = user.last_login.strftime("%H:%M")
-                                    ui.label(f"{login_date} {login_time}").classes("text-xs text-gray-500")
-                                else:
-                                    ui.label("Nie angemeldet").classes("text-xs text-gray-400")
+                            # Last login
+                            if user.last_login:
+                                login_date = user.last_login.strftime("%d.%m.%Y")
+                                login_time = user.last_login.strftime("%H:%M")
+                                ui.label(f"{login_date} {login_time}").classes("text-xs text-stone")
+                            else:
+                                ui.label("Nie angemeldet").classes("text-xs text-stone")
 
+                        # Action buttons (Solarpunk theme)
+                        with ui.row().classes("sp-admin-actions items-center gap-1"):
                             # Edit button - capture user data for the closure
                             user_id = user.id
                             username = user.username
@@ -89,26 +92,26 @@ def _render_users_list() -> None:
                                 em=email,
                                 ro=role,
                                 ia=is_active: _open_edit_dialog(uid, un, em, ro, ia),
-                            ).props("flat round color=grey-7 size=sm").mark(f"edit-{username}")
+                            ).props("flat round size=sm").classes("edit").mark(f"edit-{username}")
 
                             # Delete button - only if not current user
                             if user_id != current_user_id:
                                 ui.button(
                                     icon="delete",
                                     on_click=lambda uid=user_id, un=username: _open_delete_dialog(uid, un),
-                                ).props("flat round color=red-7 size=sm").mark(f"delete-{username}")
+                                ).props("flat round size=sm").classes("delete").mark(f"delete-{username}")
         else:
-            # Empty state (shouldn't happen since there's always at least one admin)
-            with ui.card().classes("w-full"):
+            # Empty state (Solarpunk theme)
+            with ui.card().classes("sp-dashboard-card w-full"):
                 with ui.column().classes("w-full items-center py-8"):
-                    ui.icon("person_off", size="48px").classes("text-gray-400 mb-2")
-                    ui.label("Keine Benutzer vorhanden").classes("text-gray-600 text-center")
+                    ui.icon("person_off", size="48px").classes("text-stone mb-2")
+                    ui.label("Keine Benutzer vorhanden").classes("text-charcoal text-center")
 
 
 def _open_create_dialog() -> None:
     """Open dialog to create a new user."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Neuen Benutzer erstellen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Neuen Benutzer erstellen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Username input (required)
         username_input = (
@@ -152,9 +155,9 @@ def _open_create_dialog() -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_user() -> None:
                 """Validate and save the new user."""
@@ -217,7 +220,7 @@ def _open_create_dialog() -> None:
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_user).props("color=primary")
+            ui.button("Speichern", on_click=save_user).classes("sp-btn-primary")
 
     dialog.open()
 
@@ -230,8 +233,8 @@ def _open_edit_dialog(
     current_is_active: bool,
 ) -> None:
     """Open dialog to edit an existing user."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Benutzer bearbeiten").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Benutzer bearbeiten").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Username input (pre-filled)
         username_input = (
@@ -283,9 +286,9 @@ def _open_edit_dialog(
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def save_changes() -> None:
                 """Validate and save the user changes."""
@@ -345,15 +348,15 @@ def _open_edit_dialog(
                         error_label.set_text(error_msg)
                     error_label.set_visibility(True)
 
-            ui.button("Speichern", on_click=save_changes).props("color=primary")
+            ui.button("Speichern", on_click=save_changes).classes("sp-btn-primary")
 
     dialog.open()
 
 
 def _open_delete_dialog(user_id: int, username: str) -> None:
     """Open confirmation dialog to delete a user."""
-    with ui.dialog() as dialog, ui.card().classes("w-full max-w-md"):
-        ui.label("Benutzer löschen").classes("text-h6 font-semibold mb-4")
+    with ui.dialog() as dialog, ui.card().classes("sp-dashboard-card w-full max-w-md"):
+        ui.label("Benutzer löschen").classes("text-h6 font-semibold mb-4 text-fern")
 
         # Warning message
         ui.label(f"Möchten Sie den Benutzer '{username}' wirklich löschen?").classes("mb-2")
@@ -363,9 +366,9 @@ def _open_delete_dialog(user_id: int, username: str) -> None:
         error_label = ui.label("").classes("text-red-600 text-sm mb-2")
         error_label.set_visibility(False)
 
-        # Buttons
+        # Buttons (Solarpunk theme)
         with ui.row().classes("w-full justify-end gap-2"):
-            ui.button("Abbrechen", on_click=dialog.close).props("flat")
+            ui.button("Abbrechen", on_click=dialog.close).classes("sp-btn-ghost").props("flat")
 
             def confirm_delete() -> None:
                 """Perform the deletion."""
@@ -379,6 +382,6 @@ def _open_delete_dialog(user_id: int, username: str) -> None:
                     error_label.set_text(str(e))
                     error_label.set_visibility(True)
 
-            ui.button("Löschen", on_click=confirm_delete).props("color=red")
+            ui.button("Löschen", on_click=confirm_delete).classes("sp-btn-danger")
 
     dialog.open()


### PR DESCRIPTION
## Summary
- Applied Solarpunk theme CSS classes to all 5 admin pages
- categories.py: Admin list items with color dots and themed dialogs
- locations.py: Same admin list item styling pattern
- users.py: Admin list items with themed action buttons
- settings.py: Themed navigation cards and form sections
- profile.py: Themed form cards and buttons

## Test plan
- [x] All 453 tests pass
- [x] Linting passes
- [ ] Manual verification of admin pages styling

closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)