### PR TITLE
feat: UI: Item Card Entnahme-Button Höhe und Beschriftung anpassen

### DIFF
--- a/app/ui/components/item_card.py
+++ b/app/ui/components/item_card.py
@@ -4,11 +4,11 @@ Based on Issue #173: Einheitliches Card-Design für Dashboard & Vorrat.
 Same component used in both Dashboard and Vorrat views.
 
 Card Structure (3-line version):
-┌─────────────────────────────────────────────────────────┐
-│ ▌ Name                                MHD      [ENTN.] │
-│ ▌ Menge · [Item-Type Badge]           Morgen           │
-│ ▌ 📍 Lagerort   [Kategorie]                            │
-└─────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│ ▌ Name                                MHD      [Entnahme] │
+│ ▌ Menge · [Item-Type Badge]           Morgen                  │
+│ ▌ 📍 Lagerort   [Kategorie]                                   │
+└───────────────────────────────────────────────────────────────┘
   ↑ Status-Border (4px, colored by expiry status)
 """
 
@@ -202,9 +202,9 @@ def create_item_card(
                     # Map status to Quasar color prop
                     btn_color = "negative" if status == "critical" else "warning" if status == "warning" else "positive"
                     ui.button(
-                        "Entn.",
+                        "Entnahme",
                         on_click=lambda i=item: on_consume(i),
-                    ).props(f"size=sm dense color={btn_color}").classes("mt-1")
+                    ).props(f"size=sm dense flat color={btn_color}")
 
         # Click handler for entire card (if provided)
         if on_click:

--- a/app/ui/test_pages/test_item_card.py
+++ b/app/ui/test_pages/test_item_card.py
@@ -213,3 +213,18 @@ def page_item_card_mhd_warning() -> None:
         category = _create_test_category(session, with_shelf_life=False)
         item = _create_mhd_item(session, location, category, mhd_days_from_now=5)
         create_item_card(item, session)
+
+
+# =============================================================================
+# Test pages for consume button
+# =============================================================================
+
+
+@ui.page("/test-item-card-with-consume")
+def page_item_card_with_consume() -> None:
+    """Test page for item card with consume button."""
+    with next(get_session()) as session:
+        location = _create_test_location(session)
+        category = _create_test_category(session, with_shelf_life=True)
+        item = _create_shelf_life_item(session, location, category, freeze_days_ago=30)
+        create_item_card(item, session, on_consume=lambda i: None)

--- a/tests/test_ui/test_item_card.py
+++ b/tests/test_ui/test_item_card.py
@@ -125,3 +125,14 @@ async def test_item_card_fresh_warning_shows_ablauf(user: TestUser) -> None:
     await user.open("/test-item-card-mhd-warning")
     await user.should_see("Joghurt")
     await user.should_see("Ablauf")
+
+
+# =============================================================================
+# Consume Button Tests
+# =============================================================================
+
+
+async def test_item_card_shows_entnahme_button(user: TestUser) -> None:
+    """Test that item card shows 'Entnahme' button when on_consume is provided."""
+    await user.open("/test-item-card-with-consume")
+    await user.should_see("Entnahme")


### PR DESCRIPTION
## Summary
- Button-Beschriftung von "Entn." auf "Entnahme" geändert
- Button-Höhe durch `flat` Property reduziert für bessere Anpassung an andere Card-Elemente
- Test für Button-Beschriftung hinzugefügt

## Test plan
- [x] Test `test_item_card_shows_entnahme_button` prüft Button-Beschriftung
- [x] Alle 454 Tests bestanden
- [x] Linter (ruff) und Formatter durchgelaufen

closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)