### PR TITLE
test: Replace skipped NiceGUI tests with E2E test

### DIFF
--- a/tests/test_ui/test_wizard_back_button.py
+++ b/tests/test_ui/test_wizard_back_button.py
@@ -1,15 +1,14 @@
 """UI Tests for Wizard Back Button - Issue #48.
 
-Test that going back from Step 2 to Step 1 preserves all input data.
+Test that wizard UI renders correctly.
 
-NOTE: These tests are marked as skipped because NiceGUI's testing framework
-has limitations with triggering form validation bindings programmatically.
-The fix has been verified manually and the core fix is tested implicitly
-through other wizard tests.
+NOTE: Full back-button behavior (data preservation across steps) is tested
+in E2E tests (tests/test_e2e/test_wizard.py) because NiceGUI's testing
+framework cannot trigger form validation bindings programmatically.
 
-The fix: show_step1() now uses content_container.clear() and rebuilds
-the UI (like show_step2 and show_step3) instead of ui.navigate.to()
-which was causing a full page reload and data loss.
+See:
+- test_wizard_back_button_preserves_data
+- test_wizard_back_button_roundtrip_preserves_summary
 """
 
 from app.models import Location
@@ -48,35 +47,3 @@ async def test_wizard_shows_weiter_button(logged_in_user: User, location_in_db: 
     # Navigate to wizard (already logged in via fixture)
     await logged_in_user.open("/items/add")
     await logged_in_user.should_see("Weiter")
-
-
-@pytest.mark.skip(
-    reason="NiceGUI testing framework cannot trigger form validation bindings. "
-    "Fix verified manually: show_step1() now uses content_container.clear() "
-    "instead of ui.navigate.to() to preserve form data."
-)
-async def test_back_button_preserves_product_name(logged_in_user: User, location_in_db: Location) -> None:
-    """Test that product name is preserved when going back from Step 2.
-
-    Issue #48: Going back from Step 2 to Step 1 should preserve all inputs.
-
-    This test requires being able to navigate to Step 2 first, which requires
-    passing validation. The validation bindings don't trigger correctly in
-    the test environment when setting values programmatically.
-    """
-    pass
-
-
-@pytest.mark.skip(
-    reason="NiceGUI testing framework cannot trigger form validation bindings. "
-    "Fix verified manually: show_step1() now uses content_container.clear() "
-    "instead of ui.navigate.to() to preserve form data."
-)
-async def test_back_button_preserves_summary_after_roundtrip(logged_in_user: User, location_in_db: Location) -> None:
-    """Test that going back and forward preserves all data in summary.
-
-    This roundtrip test requires navigating between steps, which requires
-    passing validation at each step. The validation bindings don't trigger
-    correctly in the test environment.
-    """
-    pass


### PR DESCRIPTION
## Summary
- Entfernt 2 permanent übersprungene Tests aus `test_wizard_back_button.py`
  - `test_back_button_preserves_product_name` war bereits durch E2E `test_wizard_back_button_preserves_data` abgedeckt
  - `test_back_button_preserves_summary_after_roundtrip` wird durch neuen E2E Test ersetzt
- Fügt neuen E2E Test `test_wizard_back_button_roundtrip_preserves_summary` hinzu
- Aktualisiert Docstring mit Verweis auf E2E Tests

## Test plan
- [x] NiceGUI UI Tests laufen ohne Skips: `uv run pytest tests/test_ui/test_wizard_back_button.py -v`
- [x] Neuer E2E Test läuft: `uv run pytest tests/test_e2e/test_wizard.py::test_wizard_back_button_roundtrip_preserves_summary -v --run-e2e`
- [x] Gesamte Test-Suite läuft (450 passed, 20 skipped statt vorher 21)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)