### PR TITLE
feat: ItemCards: Visuelle Markierung bei Entnahme + Ursprungsmenge anzeigen

### DIFF
--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -420,3 +420,24 @@ def get_withdrawal_history(session: Session, item_id: int) -> list[Withdrawal]:
             select(Withdrawal).where(Withdrawal.item_id == item_id).order_by(Withdrawal.withdrawn_at)  # type: ignore[arg-type]
         ).all()
     )
+
+
+def get_item_initial_quantity(session: Session, item_id: int) -> float:
+    """Get the initial quantity of an item before any withdrawals.
+
+    Calculates: current_quantity + sum(all withdrawals)
+
+    Args:
+        session: Database session
+        item_id: Item ID
+
+    Returns:
+        Initial quantity
+
+    Raises:
+        ValueError: If item not found
+    """
+    item = get_item(session, item_id)
+    withdrawals = get_withdrawal_history(session, item_id)
+    total_withdrawn = sum(w.quantity for w in withdrawals)
+    return item.quantity + total_withdrawn

--- a/tests/test_ui/test_item_card.py
+++ b/tests/test_ui/test_item_card.py
@@ -136,3 +136,26 @@ async def test_item_card_shows_entnahme_button(user: TestUser) -> None:
     """Test that item card shows 'Entnahme' button when on_consume is provided."""
     await user.open("/test-item-card-with-consume")
     await user.should_see("Entnahme")
+
+
+# =============================================================================
+# Partial Withdrawal Display Tests (Issue #204)
+# =============================================================================
+
+
+async def test_item_card_shows_initial_quantity_on_partial_withdrawal(
+    user: TestUser,
+) -> None:
+    """Test that item card shows initial quantity when partial withdrawal exists."""
+    await user.open("/test-item-card-partial-withdrawal")
+    # Should show "300/500 g" format
+    await user.should_see("300/500 g")
+
+
+async def test_item_card_no_initial_quantity_without_withdrawal(
+    user: TestUser,
+) -> None:
+    """Test that item card shows only current quantity when no withdrawal exists."""
+    await user.open("/test-item-card-no-withdrawal")
+    # Should show just "500 g" without initial
+    await user.should_see("500 g")


### PR DESCRIPTION
## Summary

- ItemCards zeigen bei Teilentnahme die Ursprungsmenge im Format "300/500 g" an
- Visuelle Markierung: Menge wird bei Teilentnahme in amber-Farbe angezeigt
- Neue Service-Funktion `get_item_initial_quantity()` berechnet die Ursprungsmenge aus aktueller Menge + Summe aller Entnahmen

## Änderungen

- `app/services/item_service.py`: Neue Funktion `get_item_initial_quantity()`
- `app/ui/components/item_card.py`: Neue Hilfsfunktion `_format_quantity_display()`, farbliche Markierung bei Teilentnahme
- `app/ui/test_pages/test_item_card.py`: Testseiten für Teilentnahme-Darstellung
- `tests/test_services/test_item_service.py`: 4 neue Tests für `get_item_initial_quantity()`
- `tests/test_ui/test_item_card.py`: 2 neue UI-Tests für Ursprungsmenge

## Test plan

- [x] `uv run pytest` - alle 462 Tests bestanden
- [x] `uv run mypy app/` - keine Typfehler
- [x] `uv run ruff check app/` - keine Linting-Fehler

closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)