### PR TITLE
feat: Item Card: Farbcodierte Expiry-Badges

### DIFF
--- a/app/static/css/solarpunk-theme.css
+++ b/app/static/css/solarpunk-theme.css
@@ -353,6 +353,40 @@ h1, h2, h3 {
 .sp-expiry-critical { color: var(--sp-status-critical); }
 
 /* ----------------------------------------
+   EXPIRY BADGES (Issue #212)
+   Color-coded badges for expiry status
+   ---------------------------------------- */
+.expiry-badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.expiry-badge.expired {
+  background: linear-gradient(135deg, #C44536, #D85545);
+  color: white;
+}
+
+.expiry-badge.warning {
+  background: linear-gradient(135deg, #E8985A, #F0A86A);
+  color: white;
+}
+
+.expiry-badge.soon {
+  background: linear-gradient(135deg, #D4A853, #E8C97B);
+  color: #5A4520;
+}
+
+.expiry-badge.ok {
+  background: var(--sp-cream, #FAF5EE);
+  color: var(--sp-stone, #A39E93);
+  border: 1px solid var(--sp-stone-light, #D4CFC7);
+}
+
+/* ----------------------------------------
    CHIPS - BASE
    ---------------------------------------- */
 .sp-chip {

--- a/tests/test_ui/test_item_card.py
+++ b/tests/test_ui/test_item_card.py
@@ -2,15 +2,20 @@
 
 Tests the unified item card with:
 - Item-Type Badge (Frisch, TK gekauft, Eingefr., etc.)
-- Expiry display: "MHD" + date or "Ablauf" + relative time
+- Expiry Badge: color-coded badge with date or relative time (Issue #212)
 - Status colors based on days until expiry
 """
 
+from app.models.item import ItemType
+from app.ui.components.item_card import get_expiry_badge_class
+from app.ui.components.item_card import get_expiry_badge_text
+from datetime import date
+from datetime import timedelta
 from nicegui.testing import User as TestUser
 
 
 # =============================================================================
-# Shelf-Life Item Tests (frozen items show "MHD" + date)
+# Shelf-Life Item Tests (frozen items show date format in badge)
 # =============================================================================
 
 
@@ -32,10 +37,19 @@ async def test_item_card_shows_location(user: TestUser) -> None:
     await user.should_see("Tiefkühltruhe")
 
 
-async def test_item_card_shows_mhd_label_for_frozen(user: TestUser) -> None:
-    """Test that frozen item card displays MHD label."""
+async def test_item_card_shows_date_badge_for_frozen(user: TestUser) -> None:
+    """Test that frozen item card displays date format in expiry badge."""
     await user.open("/test-item-card")
-    await user.should_see("MHD")
+    # Frozen items show date format (DD.MM.YY) in badge
+    # Test page creates item frozen 30 days ago with 6-12 month shelf life
+    # So badge shows optimal date (freeze_date + 6 months)
+    freeze_date = date.today() - timedelta(days=30)
+    optimal_date = date(
+        freeze_date.year + (freeze_date.month + 6 - 1) // 12,
+        (freeze_date.month + 6 - 1) % 12 + 1,
+        min(freeze_date.day, 28),  # Safe day for all months
+    )
+    await user.should_see(optimal_date.strftime("%d.%m.%y"))
 
 
 async def test_item_card_shows_item_type_badge(user: TestUser) -> None:
@@ -79,7 +93,7 @@ async def test_item_card_is_touch_friendly(user: TestUser) -> None:
 
 
 # =============================================================================
-# Fresh Item Tests (MHD label or Ablauf with relative time)
+# Fresh Item Tests (expiry badge with date or relative time)
 # =============================================================================
 
 
@@ -89,10 +103,13 @@ async def test_item_card_fresh_shows_product_name(user: TestUser) -> None:
     await user.should_see("Joghurt")
 
 
-async def test_item_card_fresh_shows_mhd_label(user: TestUser) -> None:
-    """Test that fresh item card shows MHD label when > 7 days."""
+async def test_item_card_fresh_shows_date_badge_when_far(user: TestUser) -> None:
+    """Test that fresh item shows date format in badge when > 7 days."""
     await user.open("/test-item-card-mhd")
-    await user.should_see("MHD")
+    # Fresh items > 7 days show date format (DD.MM.YY) in badge
+    # Test page creates item with mhd_days_from_now=10
+    expiry_date = date.today() + timedelta(days=10)
+    await user.should_see(expiry_date.strftime("%d.%m.%y"))
 
 
 async def test_item_card_fresh_shows_quantity_and_unit(user: TestUser) -> None:
@@ -113,18 +130,21 @@ async def test_item_card_fresh_shows_item_type_badge(user: TestUser) -> None:
     await user.should_see("Frisch")
 
 
-async def test_item_card_fresh_critical_shows_ablauf(user: TestUser) -> None:
-    """Test that fresh item shows 'Ablauf' when < 3 days to expiry."""
+async def test_item_card_fresh_critical_shows_relative_badge(user: TestUser) -> None:
+    """Test that fresh item shows relative text in badge when < 3 days."""
     await user.open("/test-item-card-mhd-critical")
     await user.should_see("Joghurt")
-    await user.should_see("Ablauf")
+    # Test page creates item with mhd_days_from_now=2
+    # Badge shows "in 2 Tagen"
+    await user.should_see("in 2 Tagen")
 
 
-async def test_item_card_fresh_warning_shows_ablauf(user: TestUser) -> None:
-    """Test that fresh item shows 'Ablauf' when 3-7 days to expiry."""
+async def test_item_card_fresh_warning_shows_relative_badge(user: TestUser) -> None:
+    """Test that fresh item shows 'in X Tagen' in badge when 3-7 days."""
     await user.open("/test-item-card-mhd-warning")
     await user.should_see("Joghurt")
-    await user.should_see("Ablauf")
+    # Badge shows "in X Tagen" for 5 days
+    await user.should_see("in 5 Tagen")
 
 
 # =============================================================================
@@ -209,3 +229,83 @@ async def test_item_card_progress_bar_low_level_color(
     await user.open("/test-item-card-progress-low")
     # 100/500 = 20% -> should be "negative" (coral)
     await user.should_see("20%")
+
+
+# =============================================================================
+# Unit Tests for Badge Functions (Issue #212)
+# =============================================================================
+
+
+def test_get_expiry_badge_class_expired() -> None:
+    """Test badge class for expired items (days < 0)."""
+    assert get_expiry_badge_class(-1) == "expired"
+    assert get_expiry_badge_class(-5) == "expired"
+    assert get_expiry_badge_class(-100) == "expired"
+
+
+def test_get_expiry_badge_class_warning() -> None:
+    """Test badge class for warning items (days 0-1)."""
+    assert get_expiry_badge_class(0) == "warning"
+    assert get_expiry_badge_class(1) == "warning"
+
+
+def test_get_expiry_badge_class_soon() -> None:
+    """Test badge class for soon items (days 2-7)."""
+    assert get_expiry_badge_class(2) == "soon"
+    assert get_expiry_badge_class(5) == "soon"
+    assert get_expiry_badge_class(7) == "soon"
+
+
+def test_get_expiry_badge_class_ok() -> None:
+    """Test badge class for ok items (days > 7)."""
+    assert get_expiry_badge_class(8) == "ok"
+    assert get_expiry_badge_class(30) == "ok"
+    assert get_expiry_badge_class(365) == "ok"
+
+
+def test_get_expiry_badge_text_frozen_shows_date() -> None:
+    """Test badge text for frozen items shows date format."""
+    expiry = date.today() + timedelta(days=5)
+    for item_type in [
+        ItemType.PURCHASED_FROZEN,
+        ItemType.PURCHASED_THEN_FROZEN,
+        ItemType.HOMEMADE_FROZEN,
+    ]:
+        result = get_expiry_badge_text(expiry, item_type)
+        assert result == expiry.strftime("%d.%m.%y")
+
+
+def test_get_expiry_badge_text_fresh_expired() -> None:
+    """Test badge text for expired fresh items."""
+    expiry = date.today() - timedelta(days=1)
+    result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
+    assert result == "Abgelaufen"
+
+
+def test_get_expiry_badge_text_fresh_today() -> None:
+    """Test badge text for items expiring today."""
+    expiry = date.today()
+    result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
+    assert result == "Heute"
+
+
+def test_get_expiry_badge_text_fresh_tomorrow() -> None:
+    """Test badge text for items expiring tomorrow."""
+    expiry = date.today() + timedelta(days=1)
+    result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
+    assert result == "Morgen"
+
+
+def test_get_expiry_badge_text_fresh_in_x_days() -> None:
+    """Test badge text for items expiring in 2-7 days."""
+    for days in [2, 3, 5, 7]:
+        expiry = date.today() + timedelta(days=days)
+        result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
+        assert result == f"in {days} Tagen"
+
+
+def test_get_expiry_badge_text_fresh_far_shows_date() -> None:
+    """Test badge text for fresh items > 7 days shows date format."""
+    expiry = date.today() + timedelta(days=30)
+    result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
+    assert result == expiry.strftime("%d.%m.%y")


### PR DESCRIPTION
## Summary
- Expiry-Anzeige als farbcodierte Badges statt Text mit Farbklassen
- 4 Badge-Varianten: `expired` (rot), `warning` (orange), `soon` (gold), `ok` (cream)
- Gradient-Hintergründe wie im Mockup definiert
- Badge-Text: "Abgelaufen", "Heute", "Morgen", "in X Tagen", oder Datum
- Frozen Items zeigen immer Datum-Format

## Changes
- CSS-Klassen `.expiry-badge` mit Varianten in `solarpunk-theme.css`
- Neue Funktionen `get_expiry_badge_class()` und `get_expiry_badge_text()` in `item_card.py`
- Template zeigt einzelnes Badge statt gestacktem Label+Value
- Unit-Tests für Badge-Funktionen + angepasste UI-Tests

## Test plan
- [x] Alle 30 item_card Tests bestehen
- [x] Alle 573 Tests der Testsuite bestehen
- [x] Linter (ruff) und Type-Check (mypy) ohne Fehler
- [ ] Manuell prüfen: Badge-Darstellung im Browser

closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)