### PR TITLE
feat: Item Card: Quick-Action Button (Minus)

### DIFF
--- a/app/static/css/solarpunk-theme.css
+++ b/app/static/css/solarpunk-theme.css
@@ -739,3 +739,38 @@ h1, h2, h3 {
 /* Font family */
 .font-display { font-family: var(--sp-font-display) !important; }
 .font-body { font-family: var(--sp-font-body) !important; }
+
+/* ----------------------------------------
+   QUICK-ACTION BUTTON (Issue #213)
+   Round minus button for consume action
+   ---------------------------------------- */
+.sp-quick-action {
+  width: 44px !important;
+  height: 44px !important;
+  min-width: 44px !important;
+  min-height: 44px !important;
+  border-radius: 50% !important;
+  border: 2px solid var(--sp-fern) !important;
+  background: white !important;
+  color: var(--sp-fern) !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  cursor: pointer;
+  transition: all 0.2s ease !important;
+  padding: 0 !important;
+}
+
+.sp-quick-action:hover {
+  background: var(--sp-fern) !important;
+  color: white !important;
+  transform: scale(1.05);
+}
+
+.sp-quick-action:active {
+  transform: scale(0.95);
+}
+
+.sp-quick-action .q-icon {
+  font-size: 20px !important;
+}

--- a/app/ui/components/item_card.py
+++ b/app/ui/components/item_card.py
@@ -360,13 +360,12 @@ def create_item_card(
                 .classes("quick-action-zone")
                 .style("grid-column: 2; grid-row: 2 / 4; display: flex; align-items: center; justify-content: center;")
             ):
-                # Consume button (if callback provided)
+                # Round minus button for consume action (Issue #213)
                 if on_consume:
-                    btn_color = "negative" if status == "critical" else "warning" if status == "warning" else "positive"
                     ui.button(
-                        "Entnahme",
+                        icon="remove",
                         on_click=lambda i=item: on_consume(i),
-                    ).props(f"size=sm dense flat color={btn_color}")
+                    ).classes("sp-quick-action").props("round flat")
 
             # === FOOTER ZONE ===
             # Location only

--- a/tests/test_ui/test_item_card.py
+++ b/tests/test_ui/test_item_card.py
@@ -148,14 +148,23 @@ async def test_item_card_fresh_warning_shows_relative_badge(user: TestUser) -> N
 
 
 # =============================================================================
-# Consume Button Tests
+# Quick-Action Button Tests (Issue #213)
 # =============================================================================
 
 
-async def test_item_card_shows_entnahme_button(user: TestUser) -> None:
-    """Test that item card shows 'Entnahme' button when on_consume is provided."""
+async def test_item_card_shows_quick_action_button(user: TestUser) -> None:
+    """Test that item card shows round minus button when on_consume is provided."""
     await user.open("/test-item-card-with-consume")
-    await user.should_see("Entnahme")
+    # Quick-action button should be visible (round button with minus icon)
+    # The button uses q-btn with round prop and remove icon
+    await user.should_see("remove")  # Material icon name for minus
+
+
+async def test_item_card_no_quick_action_without_consume(user: TestUser) -> None:
+    """Test that item card does NOT show quick-action button without on_consume."""
+    await user.open("/test-item-card")
+    # Should NOT see the minus icon when no consume callback
+    await user.should_not_see("remove")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Ersetzt den Text-Button "Entnahme" durch einen runden Minus-Button (44x44px)
- Hover-Effekt: Hintergrund wechselt zu Fern-Grün, Icon wird weiß
- Button nur sichtbar wenn `on_consume` Callback gesetzt (Dashboard)

## Changes

- `app/ui/components/item_card.py`: Runder Button mit `icon="remove"` statt Text-Button
- `app/static/css/solarpunk-theme.css`: Neue `.sp-quick-action` Klasse
- `tests/test_ui/test_item_card.py`: Tests für Quick-Action Button

## Test plan

- [x] Alle 544 Tests bestanden
- [x] mypy: Keine Typfehler
- [x] ruff: Code formatiert und gelintet

closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)