### PR TITLE
fix: Item Card zeigt falsche Restmenge bei vollständiger Entnahme

### DIFF
--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -195,6 +195,7 @@ def mark_item_consumed(session: Session, id: int, user_id: int | None = None) ->
     """Mark item as consumed.
 
     Creates a Withdrawal entry to track when and by whom the item was consumed.
+    Sets quantity to 0 to ensure correct initial quantity calculation.
 
     Args:
         session: Database session
@@ -218,6 +219,8 @@ def mark_item_consumed(session: Session, id: int, user_id: int | None = None) ->
         )
         session.add(withdrawal)
 
+    # Set quantity to 0 (Bug #222: was missing, causing wrong initial quantity calc)
+    item.quantity = 0
     item.is_consumed = True
 
     session.add(item)


### PR DESCRIPTION
## Summary

- **Bug**: `mark_item_consumed()` setzte `quantity` nicht auf 0
- **Folge**: `get_item_initial_quantity()` berechnete falsche Werte (current + withdrawn = 1+1 = 2 statt 1)
- **Symptom**: Item Card zeigte "1/2 L" statt "0/1 L" bei vollständiger Entnahme
- **Fix**: `item.quantity = 0` in `mark_item_consumed()` hinzugefügt

## Test plan

- [x] Tests für den Bug geschrieben die vorher fehlschlugen
- [x] Alle 561 Tests bestanden
- [x] mypy: keine Fehler
- [x] ruff: keine Fehler

closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)