### PR TITLE
fix: E2E Swipe Dwell-Time Tests zuverlässig gemacht

### DIFF
--- a/app/ui/components/swipe_card.py
+++ b/app/ui/components/swipe_card.py
@@ -11,11 +11,10 @@ Features:
 - Touch + Mouse support
 """
 
-import uuid
+from nicegui import ui
 from typing import Any
 from typing import Callable
-
-from nicegui import ui
+import uuid
 
 
 # SVG icons for action buttons

--- a/tests/test_e2e/_server.py
+++ b/tests/test_e2e/_server.py
@@ -45,7 +45,12 @@ def main() -> None:
     from app.models import User
     from app.models.location import LocationType
     import app.ui.pages as _pages  # noqa: F401
+    from nicegui import app
     from nicegui import ui
+
+    # Static files konfigurieren (wie in main.py)
+    # Wichtig: Der Pfad muss relativ zum PROJECT_ROOT sein
+    app.add_static_files("/static", str(PROJECT_ROOT / "app" / "static"))
 
     # Datenbank initialisieren (in-memory SQLite)
     create_db_and_tables()


### PR DESCRIPTION
## Summary

- JS Timer auf `setInterval` + `performance.now()` umgestellt (setTimeout/rAF laufen nicht zuverlässig in headless Browser)
- Static files im E2E Test-Server konfiguriert (swipe-card.js wurde nicht geladen)
- Test-Helper: `time.sleep` durch `page.wait_for_timeout` ersetzt
- Test-Selektoren präzisiert (strict mode violations behoben)

## Test plan

- [x] Alle 8 E2E Swipe-Tests grün (`uv run pytest tests/test_e2e/test_swipe_demo.py -m e2e --run-e2e`)
- [x] Alle anderen Tests grün (559 passed)
- [x] Linter/Formatter ohne Fehler

closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)