### PR TITLE
feat: Artikel bearbeiten Seite (/items/{id}/edit)

### DIFF
--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -156,6 +156,12 @@ def update_item(
     id: int,
     product_name: str | None = None,
     quantity: float | None = None,
+    unit: str | None = None,
+    best_before_date: date | None = None,
+    freeze_date: date | None = None,
+    location_id: int | None = None,
+    category_id: int | None = None,
+    item_type: ItemType | None = None,
     notes: str | None = None,
 ) -> Item:
     """Update item.
@@ -165,6 +171,12 @@ def update_item(
         id: Item ID
         product_name: New product name
         quantity: New quantity
+        unit: New unit
+        best_before_date: New best before date
+        freeze_date: New freeze date
+        location_id: New location ID
+        category_id: New category ID
+        item_type: New item type
         notes: New notes
 
     Returns:
@@ -180,6 +192,24 @@ def update_item(
 
     if quantity is not None:
         item.quantity = quantity
+
+    if unit is not None:
+        item.unit = unit
+
+    if best_before_date is not None:
+        item.best_before_date = best_before_date
+
+    if freeze_date is not None:
+        item.freeze_date = freeze_date
+
+    if location_id is not None:
+        item.location_id = location_id
+
+    if category_id is not None:
+        item.category_id = category_id
+
+    if item_type is not None:
+        item.item_type = item_type
 
     if notes is not None:
         item.notes = notes

--- a/app/ui/pages/__init__.py
+++ b/app/ui/pages/__init__.py
@@ -8,6 +8,7 @@ from . import categories  # noqa: F401
 from . import dashboard  # noqa: F401
 from . import demo_chips  # noqa: F401  # Temporary demo page
 from . import demo_swipe  # noqa: F401  # Swipe component demo page
+from . import edit_item  # noqa: F401
 from . import items  # noqa: F401
 from . import locations  # noqa: F401
 from . import login  # noqa: F401

--- a/app/ui/pages/edit_item.py
+++ b/app/ui/pages/edit_item.py
@@ -1,0 +1,311 @@
+"""Item Edit Page - Edit existing items."""
+
+from ...auth import require_auth
+from ...database import get_session
+from ...models.item import ItemType
+from ...services import category_service
+from ...services import item_service
+from ...services import location_service
+from ..components import create_bottom_nav
+from ..components import create_category_chip_group
+from ..components import create_item_type_chip_group
+from ..components import create_location_chip_group
+from ..components import create_mobile_page_container
+from ..components import create_unit_chip_group
+from ..theme.icons import create_icon
+from ..validation import requires_category
+from datetime import date as date_type
+from nicegui import ui
+from typing import Any
+
+
+@ui.page("/items/{item_id}/edit")
+@require_auth
+def edit_item(item_id: int) -> None:
+    """Edit-Seite fuer einen bestehenden Artikel."""
+    # Load item from database
+    try:
+        with next(get_session()) as session:
+            item = item_service.get_item(session, item_id)
+            # Load related data
+            categories = category_service.get_all_categories(session)
+            locations = location_service.get_locations_for_item_type(session, item.item_type)
+
+            # Store item data for form
+            form_data: dict[str, Any] = {
+                "product_name": item.product_name,
+                "item_type": item.item_type,
+                "quantity": item.quantity,
+                "unit": item.unit,
+                "best_before_date": item.best_before_date,
+                "freeze_date": item.freeze_date,
+                "notes": item.notes or "",
+                "location_id": item.location_id,
+                "category_id": item.category_id,
+            }
+    except ValueError:
+        # Item not found
+        with ui.row().classes("sp-page-header w-full items-center justify-between"):
+            ui.label("Fehler").classes("sp-page-title")
+            with ui.button(on_click=lambda: ui.navigate.to("/items")).classes("sp-back-btn").props("flat round"):
+                create_icon("actions/close", size="24px")
+
+        container = create_mobile_page_container()
+        with container:
+            ui.label("Artikel nicht gefunden").classes("text-lg text-red-600 mb-4")
+            ui.button("Zurueck zur Uebersicht", on_click=lambda: ui.navigate.to("/items")).props("color=primary")
+
+        create_bottom_nav(current_page="items")
+        return
+
+    # References for validation
+    save_button: Any = None
+
+    def update_validation() -> None:
+        """Update save button state based on validation."""
+        is_valid = bool(
+            form_data["product_name"]
+            and form_data["item_type"]
+            and form_data["quantity"]
+            and form_data["quantity"] > 0
+            and form_data["unit"]
+            and form_data["location_id"]
+        )
+        # Check category requirement
+        if requires_category(form_data["item_type"]) and not form_data.get("category_id"):
+            is_valid = False
+
+        if is_valid:
+            save_button.props(remove="disabled")
+        else:
+            save_button.props(add="disabled")
+
+    def update_locations_for_item_type() -> None:
+        """Update available locations when item type changes."""
+        nonlocal locations
+        with next(get_session()) as session:
+            locations = location_service.get_locations_for_item_type(session, form_data["item_type"])
+        # Rebuild location chips
+        location_container.clear()
+        with location_container:
+            create_location_chip_group(
+                locations=locations,
+                value=form_data.get("location_id"),
+                on_change=on_location_change,
+            )
+        update_validation()
+
+    def on_location_change(location_id: int) -> None:
+        form_data["location_id"] = location_id
+        update_validation()
+
+    def save_item() -> None:
+        """Save changes to database."""
+        try:
+            with next(get_session()) as session:
+                item_service.update_item(
+                    session=session,
+                    id=item_id,
+                    product_name=form_data["product_name"],
+                    quantity=form_data["quantity"],
+                    unit=form_data["unit"],
+                    best_before_date=form_data["best_before_date"],
+                    freeze_date=form_data.get("freeze_date"),
+                    location_id=form_data["location_id"],
+                    category_id=form_data.get("category_id"),
+                    item_type=form_data["item_type"],
+                    notes=form_data.get("notes") or None,
+                )
+            ui.notify(f"{form_data['product_name']} gespeichert!", type="positive")
+            ui.navigate.to("/items")
+        except Exception as e:
+            ui.notify(f"Fehler beim Speichern: {str(e)}", type="negative")
+
+    # Header with title and close button (Solarpunk theme)
+    with ui.row().classes("sp-page-header w-full items-center justify-between"):
+        ui.label("Artikel bearbeiten").classes("sp-page-title")
+        with (
+            ui.button(on_click=lambda: ui.navigate.to("/items"))
+            .classes("sp-back-btn")
+            .props("flat round")
+            .mark("edit-close")
+        ):
+            create_icon("actions/close", size="24px")
+
+    # Main content container
+    content_container = create_mobile_page_container()
+    with content_container:
+        # Product Name
+        ui.label("Produktname *").classes("text-sm font-medium mb-1")
+        product_name_input = (
+            ui.input(placeholder="z.B. Tomaten aus Garten", value=form_data["product_name"])
+            .classes("w-full")
+            .props("outlined")
+        )
+        product_name_input.bind_value(form_data, "product_name")
+        product_name_input.on("blur", update_validation)
+
+        # Item Type
+        ui.label("Artikel-Typ *").classes("text-sm font-medium mb-2 mt-4")
+
+        def on_item_type_change(value: ItemType) -> None:
+            form_data["item_type"] = value
+            update_locations_for_item_type()
+            # Show/hide category based on item type
+            category_section.set_visibility(requires_category(value))
+            # Show/hide freeze date based on item type
+            freeze_date_section.set_visibility(
+                value
+                in {
+                    ItemType.PURCHASED_THEN_FROZEN,
+                    ItemType.HOMEMADE_FROZEN,
+                }
+            )
+            update_validation()
+
+        create_item_type_chip_group(
+            value=form_data["item_type"],
+            on_change=on_item_type_change,
+        )
+
+        # Quantity
+        ui.label("Menge *").classes("text-sm font-medium mb-1 mt-4")
+        quantity_input = (
+            ui.number(
+                placeholder="z.B. 500",
+                min=0,
+                step=1,
+                value=form_data["quantity"],
+            )
+            .classes("w-full")
+            .props("outlined clearable")
+        )
+        quantity_input.bind_value(form_data, "quantity")
+        quantity_input.on("blur", update_validation)
+
+        # Unit
+        ui.label("Einheit *").classes("text-sm font-medium mb-1 mt-4")
+
+        def on_unit_change(value: str) -> None:
+            form_data["unit"] = value
+            update_validation()
+
+        create_unit_chip_group(
+            value=form_data["unit"],
+            on_change=on_unit_change,
+        )
+
+        # Category (conditional based on item type)
+        needs_category = requires_category(form_data["item_type"])
+        with ui.element("div").classes("mt-4") as category_section:
+            category_section.set_visibility(needs_category)
+            ui.label("Kategorie *").classes("text-sm font-medium mb-2")
+
+            def on_category_change(category_id: int) -> None:
+                form_data["category_id"] = category_id
+                update_validation()
+
+            create_category_chip_group(
+                categories=categories,
+                value=form_data.get("category_id"),
+                on_change=on_category_change,
+            )
+
+        # Best Before Date / Production Date
+        item_type = form_data["item_type"]
+        if item_type in {ItemType.PURCHASED_FRESH, ItemType.PURCHASED_FROZEN}:
+            date_label = "Mindesthaltbarkeitsdatum *"
+        elif item_type == ItemType.PURCHASED_THEN_FROZEN:
+            date_label = "Einkaufsdatum *"
+        else:
+            date_label = "Produktionsdatum *"
+
+        ui.label(date_label).classes("text-sm font-medium mb-1 mt-4")
+        date_value = form_data.get("best_before_date") or date_type.today()
+        form_data["best_before_date"] = date_value
+
+        with (
+            ui.input(value=date_value.strftime("%d.%m.%Y"))
+            .classes("w-full")
+            .props('outlined mask="##.##.####"')
+            .style("max-width: 500px") as date_input
+        ):
+            with date_input.add_slot("append"):
+                with ui.element("div").classes("cursor-pointer"):
+                    create_icon("status/calendar", size="24px")
+                    with ui.menu() as date_menu:
+                        date_picker = ui.date().bind_value(date_input).props('locale="de" mask="DD.MM.YYYY"')
+
+                        def on_date_change(e: Any) -> None:
+                            date_menu.close()
+                            if e.value:
+                                form_data["best_before_date"] = e.value
+                            update_validation()
+
+                        date_picker.on("update:model-value", on_date_change)
+
+        # Freeze Date (conditional)
+        show_freeze_date = form_data["item_type"] in {
+            ItemType.PURCHASED_THEN_FROZEN,
+            ItemType.HOMEMADE_FROZEN,
+        }
+        with ui.element("div").classes("mt-4") as freeze_date_section:
+            freeze_date_section.set_visibility(show_freeze_date)
+            ui.label("Einfrierdatum *").classes("text-sm font-medium mb-1")
+            freeze_date_value = form_data.get("freeze_date") or date_type.today()
+            if show_freeze_date:
+                form_data["freeze_date"] = freeze_date_value
+
+            with (
+                ui.input(value=freeze_date_value.strftime("%d.%m.%Y") if freeze_date_value else "")
+                .classes("w-full")
+                .props('outlined mask="##.##.####"')
+                .style("max-width: 500px") as freeze_date_input
+            ):
+                with freeze_date_input.add_slot("append"):
+                    with ui.element("div").classes("cursor-pointer"):
+                        create_icon("status/calendar", size="24px")
+                        with ui.menu() as freeze_date_menu:
+                            freeze_date_picker = (
+                                ui.date().bind_value(freeze_date_input).props('locale="de" mask="DD.MM.YYYY"')
+                            )
+
+                            def on_freeze_date_change(e: Any) -> None:
+                                freeze_date_menu.close()
+                                if e.value:
+                                    form_data["freeze_date"] = e.value
+                                update_validation()
+
+                            freeze_date_picker.on("update:model-value", on_freeze_date_change)
+
+        # Location
+        ui.label("Lagerort *").classes("text-sm font-medium mb-1 mt-4")
+        location_container = ui.element("div")
+        with location_container:
+            create_location_chip_group(
+                locations=locations,
+                value=form_data.get("location_id"),
+                on_change=on_location_change,
+            )
+
+        # Notes (optional)
+        ui.label("Notizen (optional)").classes("text-sm font-medium mb-1 mt-4")
+        notes_input = (
+            ui.textarea(placeholder="z.B. je 12 Stueck, 300g pro Packung", value=form_data["notes"])
+            .classes("w-full")
+            .props("outlined rows=2")
+        )
+        notes_input.bind_value(form_data, "notes")
+
+        # Save Button
+        with ui.row().classes("w-full justify-end mt-6 gap-2"):
+            with ui.button(on_click=save_item).props("color=primary size=lg").style("min-height: 48px") as save_button:
+                with ui.row().classes("items-center gap-2"):
+                    create_icon("actions/save", size="20px")
+                    ui.label("Speichern")
+
+        # Initial validation
+        update_validation()
+
+    # Bottom Navigation
+    create_bottom_nav(current_page="items")

--- a/tests/test_ui/test_edit_item.py
+++ b/tests/test_ui/test_edit_item.py
@@ -1,0 +1,58 @@
+"""UI Tests for Item Edit Page (/items/{id}/edit)."""
+
+from app.models import ItemType
+from app.models import LocationType
+from app.services import category_service
+from app.services import item_service
+from app.services import location_service
+from datetime import date
+from nicegui.testing import User
+from sqlmodel import Session
+
+
+async def test_edit_item_route_requires_auth(user: User) -> None:
+    """Test that /items/1/edit requires authentication."""
+    await user.open("/items/1/edit")
+    # Should redirect to login
+    await user.should_see("Benutzername")
+
+
+async def test_edit_item_page_shows_form(logged_in_user: User, isolated_test_database) -> None:
+    """Test that edit page shows a form with item fields."""
+    # Create test data in the isolated database
+    with Session(isolated_test_database) as session:
+        location = location_service.create_location(
+            session=session,
+            name="Kuehlschrank",
+            location_type=LocationType.CHILLED,
+            created_by=1,  # admin user
+        )
+        category = category_service.create_category(
+            session=session,
+            name="Milchprodukte",
+            created_by=1,
+        )
+        item = item_service.create_item(
+            session=session,
+            product_name="Testmilch",
+            best_before_date=date(2025, 12, 31),
+            quantity=1.0,
+            unit="L",
+            item_type=ItemType.PURCHASED_FRESH,
+            location_id=location.id,
+            created_by=1,
+            category_id=category.id,
+        )
+        item_id = item.id
+
+    await logged_in_user.open(f"/items/{item_id}/edit")
+    # Should show edit form title
+    await logged_in_user.should_see("Artikel bearbeiten")
+    # Should show product name
+    await logged_in_user.should_see("Testmilch")
+
+
+async def test_edit_item_page_shows_404_for_nonexistent_item(logged_in_user: User) -> None:
+    """Test that edit page shows error for non-existent item."""
+    await logged_in_user.open("/items/99999/edit")
+    await logged_in_user.should_see("nicht gefunden")


### PR DESCRIPTION
## Summary

- Neue Route `/items/{id}/edit` für die Bearbeitung bestehender Artikel
- Erweiterung von `item_service.update_item` um alle Item-Felder (unit, best_before_date, freeze_date, location_id, category_id, item_type)
- Vollständiges Bearbeitungsformular mit Solarpunk Theme

## Changes

- `app/ui/pages/edit_item.py`: Neue Edit-Seite mit Formular
- `app/services/item_service.py`: `update_item` um weitere Felder erweitert
- `app/ui/pages/__init__.py`: Edit-Seite registriert
- `tests/test_ui/test_edit_item.py`: UI-Tests für die Edit-Seite

## Testing

- 3 UI-Tests für Edit-Seite (Auth, Form-Anzeige, 404-Handling)
- Alle 564 Tests bestanden

Closes #235