### PR TITLE
feat: Item Card Swipe Entnahme-Aktionen (Teil/Alles)

### DIFF
--- a/app/ui/pages/dashboard.py
+++ b/app/ui/pages/dashboard.py
@@ -46,6 +46,8 @@ def dashboard() -> None:
                         item,
                         session,
                         on_consume=lambda i=item: handle_consume(i),  # type: ignore[misc]
+                        on_partial_consume=lambda i=item: handle_consume(i),  # type: ignore[misc]
+                        on_consume_all=lambda i=item: handle_consume_all(i),  # type: ignore[misc]
                         on_edit=lambda i=item: ui.navigate.to(f"/items/{i.id}/edit"),  # type: ignore[misc]
                     )
             else:
@@ -114,3 +116,11 @@ def handle_consume(item: Item) -> None:
             on_consume=lambda _: refresh_dashboard(),
         )
         sheet.open()
+
+
+def handle_consume_all(item: Item) -> None:
+    """Handle consuming all of an item via swipe action (Issue #226)."""
+    with next(get_session()) as session:
+        item_service.mark_item_consumed(session, item.id)  # type: ignore[arg-type]
+        ui.notify(f"{item.product_name} komplett entnommen", type="positive")
+    ui.navigate.to("/dashboard")

--- a/app/ui/pages/items.py
+++ b/app/ui/pages/items.py
@@ -248,12 +248,14 @@ def items_page() -> None:
                     else:
                         _render_empty_state()
                 elif filtered_items:
-                    # Display filtered items as cards with consume button and swipe edit
+                    # Display filtered items as cards with consume button and swipe actions
                     for item in filtered_items:
                         create_item_card(
                             item,
                             session,
                             on_consume=handle_consume,
+                            on_partial_consume=handle_consume,  # Swipe "Teil" -> opens dialog
+                            on_consume_all=handle_consume_all,  # Swipe "Alles" -> consume all
                             on_edit=lambda i=item: ui.navigate.to(f"/items/{i.id}/edit"),  # type: ignore[misc]
                         )
                 else:
@@ -338,6 +340,13 @@ def items_page() -> None:
                 on_consume=lambda _: refresh_items(),
             )
             sheet.open()
+
+    def handle_consume_all(item: Item) -> None:
+        """Handle consuming all of an item via swipe action (Issue #226)."""
+        with next(get_session()) as session:
+            item_service.mark_item_consumed(session, item.id)  # type: ignore[arg-type]
+            ui.notify(f"{item.product_name} komplett entnommen", type="positive")
+        refresh_items()
 
     # Header with toggle (Solarpunk theme)
     with ui.row().classes("sp-page-header w-full items-center justify-between"):


### PR DESCRIPTION
## Summary

Aktiviert die Swipe-Entnahme-Aktionen für Item Cards im Dashboard und in der Vorrats-Übersicht:

- **Swipe nach links (kurz)**: "Teil" Button (Gold) öffnet den Teilentnahme-Dialog
- **Swipe nach links (weit)**: "Alles" Button (Grün) entnimmt kompletten Bestand
- Toast-Benachrichtigung nach erfolgreicher "Alles"-Entnahme

## Changes

- `dashboard.py`: `on_partial_consume` und `on_consume_all` Callbacks hinzugefügt
- `dashboard.py`: `handle_consume_all()` Funktion implementiert
- `items.py`: `on_partial_consume` und `on_consume_all` Callbacks hinzugefügt
- `items.py`: `handle_consume_all()` Funktion implementiert

## Technical Notes

Die Swipe-Infrastruktur (CSS/JS, `swipe_card.py`) war bereits durch Issue #214 vorhanden:
- 500ms Dwell-Time mit Progress-Ring für visuelle Rückmeldung
- Swipe-through für "Alles" und "Edit"
- Bidirektionales Swipen (links: Teil/Alles, rechts: Edit)

Dieses Issue aktiviert lediglich die Callbacks in den Page-Komponenten.

## Testing

- [x] Linter (`ruff check`) bestanden
- [x] Formatter (`ruff format`) bestanden
- [x] UI-Tests (`pytest tests/test_ui/test_item_card.py`) - 36/36 passed
- [x] Typecheck (`mypy`) bestanden
- [x] E2E-Tests vorhanden (brauchen `--run-e2e` Flag)

Closes #226