### PR TITLE
feat: Item Card zeigt Temperatur-Icon statt Location-Pin (#197)

### DIFF
--- a/tests/test_ui/test_item_card.py
+++ b/tests/test_ui/test_item_card.py
@@ -318,3 +318,32 @@ def test_get_expiry_badge_text_fresh_far_shows_date() -> None:
     expiry = date.today() + timedelta(days=30)
     result = get_expiry_badge_text(expiry, ItemType.PURCHASED_FRESH)
     assert result == expiry.strftime("%d.%m.%y")
+
+
+# =============================================================================
+# Location Temperature Icon Tests (Issue #197)
+# =============================================================================
+
+
+def test_get_location_icon_frozen() -> None:
+    """Test that FROZEN location type returns freezer icon."""
+    from app.models.location import LocationType
+    from app.ui.components.item_card import get_location_icon_name
+
+    assert get_location_icon_name(LocationType.FROZEN) == "locations/freezer"
+
+
+def test_get_location_icon_chilled() -> None:
+    """Test that CHILLED location type returns fridge icon."""
+    from app.models.location import LocationType
+    from app.ui.components.item_card import get_location_icon_name
+
+    assert get_location_icon_name(LocationType.CHILLED) == "locations/fridge"
+
+
+def test_get_location_icon_ambient() -> None:
+    """Test that AMBIENT location type returns pantry icon."""
+    from app.models.location import LocationType
+    from app.ui.components.item_card import get_location_icon_name
+
+    assert get_location_icon_name(LocationType.AMBIENT) == "locations/pantry"


### PR DESCRIPTION
## Summary

- Ersetzt das 📍 Pin-Emoji in der Item Card durch Temperatur-Icons
- Icon wird basierend auf dem Lagerort-Typ (LocationType) gewählt:
  - `FROZEN` → `locations/freezer`
  - `CHILLED` → `locations/fridge`
  - `AMBIENT` → `locations/pantry`
- Lagerort-Name wird weiterhin als Text neben dem Icon angezeigt
- Icon-Farbe nutzt die Lagerort-Farbe (falls vorhanden) oder Standard-Stone-Farbe

## Test plan

- [x] Unit-Tests für `get_location_icon_name()` hinzugefügt
- [x] Alle 39 item_card Tests bestehen
- [x] mypy Type-Check erfolgreich
- [ ] Manuelle Prüfung: Item Cards in Dashboard/Vorrat zeigen korrektes Temperatur-Icon

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)