### PR TITLE
fix: dev-server.sh erkennt Worktree nicht korrekt

### DIFF
--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -11,7 +11,7 @@ set -e
 CURRENT_DIR=$(pwd)
 ISSUE_NUM=""
 
-if [[ "$CURRENT_DIR" =~ worktrees/issue-([0-9]+) ]]; then
+if [[ "$CURRENT_DIR" =~ \.worktrees/fuellhorn-([0-9]+) ]]; then
     ISSUE_NUM="${BASH_REMATCH[1]}"
     PORT=$((8000 + ISSUE_NUM))
     echo "📂 Worktree für Issue #$ISSUE_NUM erkannt"


### PR DESCRIPTION
## Summary

Behebt die Worktree-Erkennung in `scripts/dev-server.sh`, die den falschen Pfad-Pattern verwendete.

## Changes

- Regex-Pattern von `worktrees/issue-([0-9]+)` auf `\.worktrees/fuellhorn-([0-9]+)` geändert
- Jetzt wird der tatsächliche Worktree-Pfad (z.B. `.worktrees/fuellhorn-251`) korrekt erkannt
- Port wird entsprechend gesetzt (z.B. 8251 für Issue 251)

## Testing

Manuell getestet:
- ✅ Worktree `/home/.../fuellhorn/.worktrees/fuellhorn-251` → Port 8251
- ✅ Hauptrepo `/home/.../fuellhorn` → Port 8080

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)