### PR TITLE
perf: E2E: Admin-Passwort pre-hashen statt bcrypt pro Test

### DIFF
--- a/tests/test_e2e/_server.py
+++ b/tests/test_e2e/_server.py
@@ -67,14 +67,18 @@ def main() -> None:
     create_db_and_tables()
 
     # Admin-User erstellen
+    # Pre-computed bcrypt hash für "admin" - vermeidet ~100-200ms bcrypt pro Test
+    # Generiert mit: bcrypt.hashpw(b'admin', bcrypt.gensalt()).decode('utf-8')
+    ADMIN_PASSWORD_HASH = "$2b$12$8wqw9nFQlSAdV3SPd9bLZuUzOtK2.YowC9dXnjNvkCkp/1iSQenke"
+
     with next(get_session()) as session:
         admin = User(
             username="admin",
             email="admin@test.com",
             is_active=True,
             role="admin",
+            password_hash=ADMIN_PASSWORD_HASH,  # Pre-hashed für Performance
         )
-        admin.set_password("admin")  # Einfaches Passwort für E2E Tests
         session.add(admin)
         session.commit()
         session.refresh(admin)


### PR DESCRIPTION
## Summary

- Verwendet pre-computed bcrypt Hash für Admin-Password in E2E Tests
- Spart ~100-200ms bcrypt-Berechnung pro Server-Start
- Bei 37 E2E Tests: ~4-8s Zeitersparnis

## Changes

- `tests/test_e2e/_server.py`: `set_password("admin")` ersetzt durch direkte Zuweisung von `password_hash` mit pre-computed Hash

## Testing

- ✅ Login E2E Tests bestanden (3/3)
- ✅ Wizard E2E Tests mit Login funktionieren
- ✅ 374 reguläre Tests (API, UI, Unit) bestanden

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)