### PR TITLE
docs: E2E: pytest-xdist für parallele Testausführung aktivieren

### DIFF
--- a/docs/agent/tests_schreiben.md
+++ b/docs/agent/tests_schreiben.md
@@ -20,6 +20,28 @@ uv run pytest -m e2e --run-e2e
 uv run pytest tests/test_services/test_item_service.py -v
 ```
 
+### Parallele Ausführung mit pytest-xdist
+
+Tests können mit mehreren Workern parallel ausgeführt werden:
+
+```bash
+# Mit 4 parallelen Workern
+uv run pytest -n 4
+
+# Automatisch (nutzt alle CPU-Kerne)
+uv run pytest -n auto
+
+# E2E parallel (empfohlen, ~75% schneller)
+uv run pytest -m e2e --run-e2e -n auto
+```
+
+**Warum funktioniert das?**
+- Jeder Test bekommt eigenen Port (`_find_free_port()`)
+- Separate in-memory SQLite-DB pro Test
+- Eigene Browser-Instanz pro E2E-Test
+
+**CI:** E2E-Tests laufen im CI automatisch mit `-n auto`.
+
 ## Fixtures
 
 Definiert in `tests/conftest.py` - einfach als Parameter verwenden:


### PR DESCRIPTION
## Summary

Dokumentiert die parallele Testausführung mit pytest-xdist in `docs/agent/tests_schreiben.md`.

Die xdist-Parallelisierung im CI wurde bereits in #263 aktiviert (Commit 4dbeb03). Dieses Issue vervollständigt die Arbeit durch Dokumentation.

## Changes

- Neuer Abschnitt "Parallele Ausführung mit pytest-xdist" in der Test-Dokumentation
- Beispiele für `-n 4` und `-n auto`
- Erklärt warum Tests isoliert und parallel-sicher sind

## Testing

E2E-Tests erfolgreich mit `-n 4` ausgeführt:
- 37 Tests in ~29s (statt ~150s sequentiell)
- Keine Race Conditions oder Failures

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)