### PR TITLE
chore: Suppress NiceGUI User class pytest collection warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ testpaths = ["tests"]
 markers = [
     "e2e: End-to-End tests with Playwright (run with --run-e2e)",
 ]
+filterwarnings = [
+    "ignore:cannot collect test class 'User':pytest.PytestCollectionWarning",
+]
 
 [tool.mypy]
 python_version = "3.14"


### PR DESCRIPTION
## Summary

- Add pytest filterwarnings configuration to suppress `PytestCollectionWarning` for NiceGUI's `User` class
- This eliminates 7 warnings that appeared in CI test output

## Changes

- Added `filterwarnings` option to `[tool.pytest.ini_options]` in `pyproject.toml`

## Testing

- Ran full test suite (`uv run pytest`) - all 620 tests pass
- Verified no more collection warnings about `User` class appear in output

Closes #191