### PR TITLE
feat: GitHub Workflow Tests (Pytest + Coverage)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install Python 3.14
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests with coverage
+        run: uv run pytest -m "not e2e" --cov=app --cov-report=xml --cov-report=term
+        env:
+          SECRET_KEY: test-secret-key-for-ci-only
+          FUELLHORN_SECRET: test-fuellhorn-secret-for-ci-only
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tests.yaml` as a reusable workflow (`workflow_call`)
- Runs pytest with coverage reporting (XML + terminal output)
- Excludes E2E tests (`-m "not e2e"`) since they require Playwright/browser
- Uploads `coverage.xml` as artifact with 7-day retention

Closes #277

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Workflow can be called from another workflow using `uses: ./.github/workflows/tests.yaml`
- [ ] Coverage artifact is uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)