### PR TITLE
feat: GitHub Workflow: QA (Ruff + Mypy)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,44 @@
+name: QA
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint (Ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run Ruff check
+        run: uv run ruff check app/
+
+      - name: Run Ruff format check
+        run: uv run ruff format --check app/
+
+  typecheck:
+    name: Type Check (Mypy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run Mypy
+        run: uv run mypy app/


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Actions workflow for code quality checks. The workflow is designed to be called from other workflows using `workflow_call`.

## Changes

- Created `.github/workflows/qa.yaml` with two parallel jobs:
  - **Lint (Ruff)**: Runs `ruff check` and `ruff format --check` on `app/`
  - **Type Check (Mypy)**: Runs `mypy` on `app/`
- Uses `uv` with `--frozen --group dev` for dependency installation
- Includes caching via `astral-sh/setup-uv@v5` for faster builds

## Testing

- YAML syntax validated locally with Python yaml parser
- Workflow can only be fully tested after merge (workflow_call trigger)

Closes #276