### PR TITLE
feat: Dockerfile anpassen: PyPI-Installation statt Source

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,23 @@
+# Fuellhorn - Lebensmittelvorrats-Verwaltung
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Development Dockerfile - builds from source
+
+FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim
+
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY pyproject.toml uv.lock ./
+
+# Install only dependencies (not the project itself)
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Copy application code
+COPY app/ ./app/
+COPY alembic.ini ./
+COPY main.py ./
+
+EXPOSE 8080
+
+CMD ["uv", "run", "python", "main.py"]


### PR DESCRIPTION
## Summary

- Production `Dockerfile` installiert jetzt von PyPI statt Source zu bauen
- Neues `Dockerfile.dev` für lokale Entwicklung (baut von Source)
- `docker-entrypoint.sh` entfernt - CLI führt Migrations automatisch aus

## Changes

- `Dockerfile`: Vereinfacht auf PyPI-Installation mit `uv pip install --system fuellhorn==${FUELLHORN_VERSION}`
- `Dockerfile.dev`: Neues Entwicklungs-Dockerfile mit `uv sync --no-install-project` für Dependencies-Caching

## Testing

- Docker-Build mit `Dockerfile.dev` erfolgreich getestet
- CLI-Import im Container verifiziert

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)