### PR TITLE
fix: resolve static files path from package location in CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -30,7 +30,8 @@ def main() -> None:
     run_migrations()
 
     # Serve static files (CSS, icons, etc.)
-    nicegui_app.add_static_files("/static", "app/static")
+    static_dir = Path(__file__).parent / "static"
+    nicegui_app.add_static_files("/static", str(static_dir))
 
     # Load Solarpunk theme CSS and JavaScript for each client connection
     @nicegui_app.on_connect


### PR DESCRIPTION
## Summary

Fixes static file serving when fuellhorn is installed from PyPI. The CLI entry point was using a relative path (`"app/static"`) which doesn't work when the working directory differs from the package location.

## Changes

- Changed `app/cli.py` to use `Path(__file__).parent / "static"` instead of hardcoded relative path `"app/static"`

## Testing

- All existing tests pass (634 passed)
- mypy and ruff checks pass
- Manual verification: `uv build && uv pip install dist/*.whl && fuellhorn` should now correctly serve CSS/JS

Closes #294