### PR TITLE
chore: update stale gitignore path for alembic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ data/*.db-journal
 .env.local
 
 # Alembic
-alembic/versions/*.pyc
+app/alembic/versions/*.pyc
 
 # NiceGUI
 .nicegui/


### PR DESCRIPTION
## Summary

Updates the `.gitignore` entry for alembic to match the new directory structure after the migration in #275.

## Changes

- Changed `alembic/versions/*.pyc` → `app/alembic/versions/*.pyc`

## Testing

No tests needed - configuration-only change.

Closes #299