### PR TITLE
docs: document DB initialization difference between dev and prod

### DIFF
--- a/docs/agent/tech_stack.md
+++ b/docs/agent/tech_stack.md
@@ -22,6 +22,87 @@
 
 Siehe [architektur_erklaert.md](architektur_erklaert.md) für das 3-Schichten-Modell.
 
+## Datenbank-Initialisierung
+
+**Wichtig:** Es gibt einen absichtlichen Unterschied zwischen Entwicklung und Produktion!
+
+### Development (`main.py`)
+
+```python
+create_db_and_tables()  # SQLModel erstellt Tabellen direkt
+```
+
+- Schneller Start ohne Migration
+- Tabellen werden aus SQLModel-Definitionen erstellt
+- Geeignet für lokale Entwicklung und schnelles Iterieren
+
+### Production (`app/cli.py`)
+
+```python
+run_migrations()  # Alembic führt Migrationen aus
+```
+
+- Verwendet Alembic-Migrationen für Schema-Änderungen
+- Versionierte, nachvollziehbare Datenbankänderungen
+- Notwendig für sichere Updates in Produktion
+
+### Warum der Unterschied?
+
+| Aspekt | Development | Production |
+|--------|-------------|------------|
+| Geschwindigkeit | ✅ Sofortiger Start | ⏱️ Migrationen brauchen Zeit |
+| Sicherheit | ⚠️ Schema wird überschrieben | ✅ Kontrollierte Updates |
+| Datenerhalt | ❌ Bei Schemaänderung verloren | ✅ Daten bleiben erhalten |
+| Nachvollziehbarkeit | ❌ Keine Historie | ✅ Versioniert |
+
+### Migrationen erstellen
+
+**Bei jeder Model-Änderung eine Migration erstellen:**
+
+```bash
+# 1. Model ändern (z.B. in app/models/)
+
+# 2. Migration generieren
+uv run alembic revision --autogenerate -m "Beschreibung der Änderung"
+
+# 3. Migration prüfen (in alembic/versions/)
+#    - Generierte SQL-Statements überprüfen
+#    - Downgrade-Funktion testen
+
+# 4. Migration lokal testen
+uv run alembic upgrade head
+```
+
+### Migrationen in Development manuell ausführen
+
+Falls du Migrationen in der Entwicklung testen willst:
+
+```bash
+# Statt main.py direkt zu starten:
+uv run alembic upgrade head
+uv run python main.py
+```
+
+Oder verwende das CLI wie in Produktion:
+
+```bash
+uv run fuellhorn
+```
+
+### Häufige Fehler vermeiden
+
+1. **Model geändert, aber keine Migration erstellt**
+   - Dev funktioniert, Prod schlägt fehl
+   - Lösung: Immer `alembic revision --autogenerate` nach Model-Änderungen
+
+2. **Schema-Drift zwischen Dev und Prod**
+   - Symptom: Tests laufen, Deployment fehlschlägt
+   - Lösung: Regelmäßig mit `alembic upgrade head` in Dev testen
+
+3. **Autogenerate erkennt nicht alle Änderungen**
+   - Alembic erkennt nicht: Tabellen-/Spaltennamen-Änderungen, Constraints
+   - Lösung: Generierte Migration manuell prüfen und anpassen
+
 ## Rollen
 
 | Rolle | Rechte |


### PR DESCRIPTION
## Summary

- Documents the intentional difference between database initialization in development vs production
- Explains why `main.py` uses `create_db_and_tables()` while `app/cli.py` uses Alembic migrations
- Provides guidance on when and how to create migrations

## Changes

- Added new "Datenbank-Initialisierung" section to `docs/agent/tech_stack.md`
- Includes comparison table showing trade-offs between dev and prod approaches
- Documents common pitfalls like schema drift and missing migrations

## Testing

Documentation-only change, no testing required.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)