### PR TITLE
docs: Fix incorrect migration command in Docker troubleshooting

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -125,9 +125,15 @@ docker compose up -d
 
 ### Migrations-Fehler
 
-Die Alembic-Migrationen werden beim Start automatisch ausgeführt. Bei Fehlern:
+Die Alembic-Migrationen werden beim Container-Start automatisch ausgeführt.
+Bei Problemen die Container-Logs prüfen:
 
 ```bash
-# Manuell Migrationen ausführen
-docker exec fuellhorn-app uv run alembic upgrade head
+docker compose logs app
+```
+
+Falls eine manuelle Migration erforderlich ist:
+
+```bash
+docker exec fuellhorn-app python -c "from app.cli import run_migrations; run_migrations()"
 ```


### PR DESCRIPTION
## Summary

Korrigiert den falschen Migrationsbefehl in der Docker-Troubleshooting-Dokumentation.

Der bisherige Befehl `docker exec fuellhorn-app uv run alembic upgrade head` funktioniert im Production-Container nicht, da:
- Das Paket von PyPI installiert ist (nicht aus Source)
- `alembic` CLI nicht direkt verfügbar ist

## Changes

- Klargestellt, dass Migrationen beim Container-Start automatisch ausgeführt werden
- Korrekten manuellen Befehl hinzugefügt: `python -c "from app.cli import run_migrations; run_migrations()"`
- Hinweis auf Container-Logs für Debugging hinzugefügt

## Testing

Dokumentationsänderung - kein Code-Test erforderlich.
Der neue Befehl entspricht der tatsächlichen Implementierung in `app/cli.py:run_migrations()`.

Closes #302