### PR TITLE
docs: explain --no-install-project usage in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,8 @@ WORKDIR /app
 # Copy dependency files first for better caching
 COPY pyproject.toml uv.lock ./
 
-# Install only dependencies (not the project itself)
+# Install dependencies only, not the project itself
+# This allows volume mounting ./app for live code reloading
 RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy application code


### PR DESCRIPTION
## Summary

Dokumentiert warum `--no-install-project` in Dockerfile.dev verwendet wird - es ermöglicht Volume-Mounting für Live-Code-Reloading während der Entwicklung.

## Changes

- Kommentar in Dockerfile.dev erweitert um den Zweck zu erklären

## Testing

Keine Tests nötig - reine Dokumentationsänderung.

Closes #303