### PR TITLE
perf: Split CI tests into parallel jobs for ~40% speedup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,8 +4,41 @@ on:
   workflow_call:
 
 jobs:
-  test:
-    name: Run Tests
+  test-fast:
+    name: Unit & Service Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install Python 3.14
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run unit & service tests (parallel)
+        run: uv run pytest tests/test_services tests/test_api tests/test_unit tests/test_auth tests/test_utils tests/test_cli.py tests/test_config.py tests/test_database_isolation.py -n auto --cov=app --cov-report=xml
+        env:
+          SECRET_KEY: test-secret-key-for-ci-only
+          FUELLHORN_SECRET: test-fuellhorn-secret-for-ci-only
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-fast
+          path: coverage.xml
+          retention-days: 7
+
+  test-ui:
+    name: UI Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -24,8 +57,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Run tests with coverage
-        run: uv run pytest -m "not e2e" --cov=app --cov-report=xml --cov-report=term
+      - name: Run UI tests
+        run: uv run pytest tests/test_ui --cov=app --cov-report=xml --cov-report=term
         env:
           SECRET_KEY: test-secret-key-for-ci-only
           FUELLHORN_SECRET: test-fuellhorn-secret-for-ci-only
@@ -33,6 +66,6 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-ui
           path: coverage.xml
           retention-days: 7


### PR DESCRIPTION
## Summary

Split the test workflow into two parallel jobs to reduce CI time by ~40%.

## Changes

- **test-fast**: Unit/Service/API/Auth/Utils tests with `pytest-xdist -n auto`
  - 366 tests in ~11s (was ~37s serially)
- **test-ui**: UI tests run serially (DB isolation prevents parallelization)
  - 284 tests in ~55s

## Measurements

| Test Group | Serial | Parallel | Speedup |
|------------|--------|----------|---------|
| Unit/Service/API | 37.4s | 10.9s | **3.5x** |
| UI | 55.0s | N/A (race conditions) | - |
| **Total CI** | ~92s | **~55s** | **~40%** |

## Testing

- Ran both test groups locally, all tests pass
- pytest-xdist already in dependencies

Closes #322

Closes #322