### PR TITLE
fix: Use psycopg3 dialect for PostgreSQL database URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,11 +48,24 @@ class Config:
 
     @classmethod
     def get_database_url(cls) -> str:
-        """Gibt die Datenbank-URL zurück."""
+        """Gibt die Datenbank-URL zurück.
+
+        Für PostgreSQL wird automatisch der psycopg3 Dialekt verwendet.
+        URLs mit postgresql:// werden zu postgresql+psycopg:// konvertiert.
+        """
         if cls.DB_TYPE == "sqlite":
             # Stelle sicher, dass das data/ Verzeichnis existiert
             DATA_DIR.mkdir(exist_ok=True)
-        return cls.DATABASE_URL
+            return cls.DATABASE_URL
+
+        # PostgreSQL: Sicherstellen dass psycopg3 Dialekt verwendet wird
+        url = cls.DATABASE_URL
+        if url.startswith("postgresql://"):
+            url = url.replace("postgresql://", "postgresql+psycopg://", 1)
+        elif url.startswith("postgres://"):
+            # Heroku-style URLs
+            url = url.replace("postgres://", "postgresql+psycopg://", 1)
+        return url
 
 
 # Singleton-Instanz

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,78 @@ class TestConfigClass:
         assert isinstance(Config.REMEMBER_ME_MAX_AGE, int)
 
 
+class TestGetDatabaseUrl:
+    """Tests for get_database_url method."""
+
+    def test_sqlite_url_unchanged(self) -> None:
+        """SQLite URLs should remain unchanged."""
+        from app.config import Config
+
+        original_db_type = Config.DB_TYPE
+        original_url = Config.DATABASE_URL
+
+        try:
+            Config.DB_TYPE = "sqlite"
+            Config.DATABASE_URL = "sqlite:///test.db"
+
+            result = Config.get_database_url()
+            assert result == "sqlite:///test.db"
+        finally:
+            Config.DB_TYPE = original_db_type
+            Config.DATABASE_URL = original_url
+
+    def test_postgresql_url_gets_psycopg_dialect(self) -> None:
+        """PostgreSQL URLs should use psycopg3 dialect."""
+        from app.config import Config
+
+        original_db_type = Config.DB_TYPE
+        original_url = Config.DATABASE_URL
+
+        try:
+            Config.DB_TYPE = "postgresql"
+            Config.DATABASE_URL = "postgresql://user:pass@localhost/db"
+
+            result = Config.get_database_url()
+            assert result == "postgresql+psycopg://user:pass@localhost/db"
+        finally:
+            Config.DB_TYPE = original_db_type
+            Config.DATABASE_URL = original_url
+
+    def test_postgres_heroku_style_url_gets_psycopg_dialect(self) -> None:
+        """Heroku-style postgres:// URLs should use psycopg3 dialect."""
+        from app.config import Config
+
+        original_db_type = Config.DB_TYPE
+        original_url = Config.DATABASE_URL
+
+        try:
+            Config.DB_TYPE = "postgresql"
+            Config.DATABASE_URL = "postgres://user:pass@localhost/db"
+
+            result = Config.get_database_url()
+            assert result == "postgresql+psycopg://user:pass@localhost/db"
+        finally:
+            Config.DB_TYPE = original_db_type
+            Config.DATABASE_URL = original_url
+
+    def test_already_correct_dialect_unchanged(self) -> None:
+        """URLs with psycopg dialect should remain unchanged."""
+        from app.config import Config
+
+        original_db_type = Config.DB_TYPE
+        original_url = Config.DATABASE_URL
+
+        try:
+            Config.DB_TYPE = "postgresql"
+            Config.DATABASE_URL = "postgresql+psycopg://user:pass@localhost/db"
+
+            result = Config.get_database_url()
+            assert result == "postgresql+psycopg://user:pass@localhost/db"
+        finally:
+            Config.DB_TYPE = original_db_type
+            Config.DATABASE_URL = original_url
+
+
 class TestMaxFileSize:
     """Tests for MAX_FILE_SIZE constant."""
 


### PR DESCRIPTION
## Summary

- SQLAlchemy requires explicit `postgresql+psycopg://` dialect for psycopg3
- Converts standard `postgresql://` and Heroku-style `postgres://` URLs to use the correct psycopg3 driver
- The psycopg3 driver (`psycopg[binary,pool]>=3`) is already in our dependencies

## Changes

- Updated `Config.get_database_url()` to automatically convert PostgreSQL URLs to use the psycopg3 dialect
- Added comprehensive tests for URL conversion

## Testing

- All 654 tests pass
- New tests verify URL conversion for:
  - SQLite URLs (unchanged)
  - `postgresql://` URLs (converted to `postgresql+psycopg://`)
  - `postgres://` Heroku-style URLs (converted to `postgresql+psycopg://`)
  - Already correct URLs (unchanged)

Closes #324