### PR TITLE
feat: Publish Helm chart to GHCR OCI registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,3 +186,35 @@ jobs:
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+
+  helm-publish:
+    name: Publish Helm Chart
+    needs: [qa, tests]
+    if: github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Update Chart.yaml version
+        run: |
+          sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" charts/fuellhorn/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" charts/fuellhorn/Chart.yaml
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push Helm chart
+        run: |
+          helm package charts/fuellhorn
+          helm push fuellhorn-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}

--- a/charts/fuellhorn/README.md
+++ b/charts/fuellhorn/README.md
@@ -10,18 +10,62 @@ Self-hosted food inventory management for Kubernetes.
 
 ## Installation
 
-### Quick Start (Testing)
+### From OCI Registry (Recommended)
+
+The chart is published to GitHub Container Registry:
 
 ```bash
-helm install fuellhorn ./charts/fuellhorn \
+# Install latest version
+helm install fuellhorn oci://ghcr.io/jensens/fuellhorn \
   --set secrets.secretKey="your-secret-key-min-32-chars-here" \
   --set secrets.fuellhornSecret="your-fuellhorn-secret-min-32-chars"
+
+# Install specific version
+helm install fuellhorn oci://ghcr.io/jensens/fuellhorn --version 0.2.0
+
+# With custom values file
+helm install fuellhorn oci://ghcr.io/jensens/fuellhorn -f my-values.yaml
+```
+
+### From Git (Development)
+
+```bash
+git clone https://github.com/jensens/fuellhorn.git
+helm install fuellhorn ./fuellhorn/charts/fuellhorn \
+  --set secrets.secretKey="your-secret-key-min-32-chars-here" \
+  --set secrets.fuellhornSecret="your-fuellhorn-secret-min-32-chars"
+```
+
+### GitOps with ArgoCD
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuellhorn
+spec:
+  source:
+    chart: fuellhorn
+    repoURL: ghcr.io/jensens
+    targetRevision: 0.2.0
+    helm:
+      values: |
+        secrets:
+          existingSecret: fuellhorn-secrets
+        database:
+          type: postgresql
+          external:
+            host: postgres.example.com
+            existingSecret: postgres-credentials
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuellhorn
 ```
 
 ### Production with PostgreSQL
 
 ```bash
-helm install fuellhorn ./charts/fuellhorn \
+helm install fuellhorn oci://ghcr.io/jensens/fuellhorn \
   --set database.type=postgresql \
   --set database.external.host=postgres.example.com \
   --set database.external.password=mypassword \
@@ -46,7 +90,7 @@ data:
 Then install:
 
 ```bash
-helm install fuellhorn ./charts/fuellhorn \
+helm install fuellhorn oci://ghcr.io/jensens/fuellhorn \
   --set secrets.existingSecret=my-fuellhorn-secrets
 ```
 
@@ -216,7 +260,11 @@ kubectl create secret generic fuellhorn-admin \
 ## Upgrading
 
 ```bash
-helm upgrade fuellhorn ./charts/fuellhorn --values my-values.yaml
+# From OCI registry
+helm upgrade fuellhorn oci://ghcr.io/jensens/fuellhorn -f my-values.yaml
+
+# From local checkout
+helm upgrade fuellhorn ./charts/fuellhorn -f my-values.yaml
 ```
 
 ## Uninstalling
@@ -254,5 +302,7 @@ helm get values fuellhorn
 ### Verify Templates
 
 ```bash
-helm template fuellhorn ./charts/fuellhorn --values my-values.yaml
+# Pull chart first for template verification
+helm pull oci://ghcr.io/jensens/fuellhorn --untar
+helm template fuellhorn ./fuellhorn -f my-values.yaml
 ```


### PR DESCRIPTION
## Summary

- Add `helm-publish` job to release workflow that packages and pushes the Helm chart to GHCR on release publication
- Update Helm chart README with OCI registry installation instructions
- Add ArgoCD GitOps example for deployments

## Changes

- `.github/workflows/release.yaml`: New `helm-publish` job that runs parallel to Docker builds
- `charts/fuellhorn/README.md`: OCI installation as recommended method, ArgoCD example, updated upgrade/verify commands

## Usage After Release

```bash
# Install from OCI registry
helm install fuellhorn oci://ghcr.io/jensens/fuellhorn

# Specific version
helm install fuellhorn oci://ghcr.io/jensens/fuellhorn --version 0.2.0

# Upgrade
helm upgrade fuellhorn oci://ghcr.io/jensens/fuellhorn
```

## Testing

- `helm lint charts/fuellhorn` passes
- Workflow syntax validated
- Will be fully testable on next release publication

Closes #330