### PR TITLE
fix: Add missing SECRET_KEY env var to create-admin init container

### DIFF
--- a/charts/fuellhorn/templates/deployment.yaml
+++ b/charts/fuellhorn/templates/deployment.yaml
@@ -69,6 +69,16 @@ spec:
               {{- else }}
               value: {{ .Values.initContainers.adminUser.password | quote }}
               {{- end }}
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.existingSecret | default (printf "%s-secrets" (include "fuellhorn.fullname" .)) }}
+                  key: secret-key
+            - name: FUELLHORN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.existingSecret | default (printf "%s-secrets" (include "fuellhorn.fullname" .)) }}
+                  key: fuellhorn-secret
           {{- if eq .Values.database.type "sqlite" }}
           volumeMounts:
             - name: data


### PR DESCRIPTION
## Summary

The `create-admin` init container was missing the `SECRET_KEY` and `FUELLHORN_SECRET` environment variables, causing it to fail with:
```
RuntimeError: SECRET_KEY environment variable must be set!
```

## Changes

- Add `SECRET_KEY` env var from secrets to create-admin init container
- Add `FUELLHORN_SECRET` env var from secrets to create-admin init container

## Testing

- `helm lint charts/fuellhorn` passes
- Template rendering verified with `helm template` shows both env vars in create-admin init container

Closes #332