### PR TITLE
fix: PWA Icons und Manifest an Root-URLs registrieren

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -9,13 +9,13 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/static/pwa/fuellhorn-icon-192.png",
+      "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/static/pwa/fuellhorn-icon-512.png",
+      "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/main.py
+++ b/main.py
@@ -9,6 +9,14 @@ from nicegui import app, ui
 # Serve static files (CSS, icons, etc.)
 app.add_static_files("/static", "app/static")
 
+# PWA: Register manifest and icons at root URLs for browser compatibility
+app.add_static_file(url_path="/manifest.json", local_file="app/static/manifest.json")
+app.add_static_file(url_path="/icon-192.png", local_file="app/static/pwa/fuellhorn-icon-192.png")
+app.add_static_file(url_path="/icon-512.png", local_file="app/static/pwa/fuellhorn-icon-512.png")
+app.add_static_file(
+    url_path="/apple-touch-icon.png", local_file="app/static/pwa/fuellhorn-icon-180.png"
+)
+
 
 # Load Solarpunk theme CSS and JavaScript for each client connection
 @app.on_connect
@@ -17,12 +25,12 @@ def _load_theme() -> None:
     ui.add_head_html('<script src="/static/js/swipe-card.js"></script>')
 
     # PWA Meta-Tags
-    ui.add_head_html('<link rel="manifest" href="/static/manifest.json">')
+    ui.add_head_html('<link rel="manifest" href="/manifest.json">')
     ui.add_head_html('<meta name="theme-color" content="#4A7C59">')
     ui.add_head_html('<meta name="mobile-web-app-capable" content="yes">')
 
     # Apple-spezifische PWA Meta-Tags
-    ui.add_head_html('<link rel="apple-touch-icon" href="/static/pwa/fuellhorn-icon-180.png">')
+    ui.add_head_html('<link rel="apple-touch-icon" href="/apple-touch-icon.png">')
     ui.add_head_html('<meta name="apple-mobile-web-app-capable" content="yes">')
     ui.add_head_html(
         '<meta name="apple-mobile-web-app-status-bar-style" content="default">'
@@ -53,6 +61,7 @@ if __name__ in {"__main__", "__mp_main__"}:
     # NiceGUI starten
     ui.run(
         title="Füllhorn - Lebensmittelvorrats-Verwaltung",
+        favicon="app/static/pwa/fuellhorn-icon-192.png",
         storage_secret=get_storage_secret(),
         port=port,
         reload=True,  # Auto-Reload waehrend Entwicklung

--- a/tests/test_pwa/test_pwa_manifest.py
+++ b/tests/test_pwa/test_pwa_manifest.py
@@ -3,9 +3,9 @@
 from nicegui.testing import User
 
 
-async def test_manifest_json_is_accessible(user: User) -> None:
-    """Manifest.json is accessible via static files."""
-    response = await user.http_client.get("/static/manifest.json")
+async def test_manifest_json_is_accessible_at_root(user: User) -> None:
+    """Manifest.json is accessible at root URL for browser compatibility."""
+    response = await user.http_client.get("/manifest.json")
 
     assert response.status_code == 200
     data = response.json()
@@ -15,8 +15,8 @@ async def test_manifest_json_is_accessible(user: User) -> None:
 
 
 async def test_manifest_contains_required_icons(user: User) -> None:
-    """Manifest.json contains required PWA icons."""
-    response = await user.http_client.get("/static/manifest.json")
+    """Manifest.json contains required PWA icons with root URLs."""
+    response = await user.http_client.get("/manifest.json")
 
     assert response.status_code == 200
     data = response.json()
@@ -24,11 +24,15 @@ async def test_manifest_contains_required_icons(user: User) -> None:
     sizes = [icon["sizes"] for icon in icons]
     assert "192x192" in sizes
     assert "512x512" in sizes
+    # Icons should use root URLs
+    sources = [icon["src"] for icon in icons]
+    assert "/icon-192.png" in sources
+    assert "/icon-512.png" in sources
 
 
 async def test_manifest_has_correct_theme_colors(user: User) -> None:
     """Manifest.json has correct Solarpunk theme colors."""
-    response = await user.http_client.get("/static/manifest.json")
+    response = await user.http_client.get("/manifest.json")
 
     assert response.status_code == 200
     data = response.json()
@@ -38,11 +42,11 @@ async def test_manifest_has_correct_theme_colors(user: User) -> None:
     assert data["background_color"] == "#FAF7F0"
 
 
-async def test_pwa_icons_are_accessible(user: User) -> None:
-    """PWA icons are accessible via static files."""
-    icon_192_response = await user.http_client.get("/static/pwa/fuellhorn-icon-192.png")
-    icon_512_response = await user.http_client.get("/static/pwa/fuellhorn-icon-512.png")
-    apple_icon_response = await user.http_client.get("/static/pwa/fuellhorn-icon-180.png")
+async def test_pwa_icons_are_accessible_at_root(user: User) -> None:
+    """PWA icons are accessible at root URLs for browser compatibility."""
+    icon_192_response = await user.http_client.get("/icon-192.png")
+    icon_512_response = await user.http_client.get("/icon-512.png")
+    apple_icon_response = await user.http_client.get("/apple-touch-icon.png")
 
     assert icon_192_response.status_code == 200
     assert icon_512_response.status_code == 200


### PR DESCRIPTION
## Summary

Behebt das Problem, dass beim Add-to-Home-Screen das NiceGUI-Logo statt des Füllhorn-Logos angezeigt wurde.

## Problem

Browser erwarten PWA-Manifest und Icons an vorhersagbaren Root-URLs. Die vorherige Implementierung unter `/static/` wurde von mobilen Browsern nicht erkannt.

## Changes

- `favicon` Parameter in `ui.run()` hinzugefügt, um das NiceGUI-Standard-Icon zu überschreiben
- `manifest.json` unter `/manifest.json` mit `app.add_static_file()` registriert
- PWA-Icons unter Root-URLs registriert:
  - `/icon-192.png`
  - `/icon-512.png`
  - `/apple-touch-icon.png`
- `manifest.json` aktualisiert, um Root-URL-Pfade für Icons zu verwenden
- Tests angepasst, um Root-URL-Zugänglichkeit zu verifizieren

## Testing

- [x] Alle Unit-Tests bestanden (676 tests)
- [x] PWA-Tests bestanden
- [x] Linter und Formatter bestanden
- [x] Typecheck bestanden

**Manuelle Verifizierung erforderlich:**
- Auf Android: "Zum Startbildschirm hinzufügen" sollte das Füllhorn-Logo zeigen
- Auf iOS: "Zum Home-Bildschirm" sollte das Füllhorn-Logo zeigen